### PR TITLE
Enhance image handling for concurrency support

### DIFF
--- a/Sources/MushafImad/Core/Extensions/PlatformImage+Extension.swift
+++ b/Sources/MushafImad/Core/Extensions/PlatformImage+Extension.swift
@@ -7,9 +7,16 @@
 
 #if canImport(UIKit)
 import UIKit
+
+// UIImage is safe to send across concurrency boundaries as it's immutable
+extension UIImage: @unchecked Sendable {}
+
 #elseif canImport(AppKit)
 import AppKit
 public typealias UIImage = NSImage
+
+// NSImage is safe to send across concurrency boundaries as it's immutable
+extension NSImage: @unchecked Sendable {}
 
 public extension NSImage {
     func pngData() -> Data? {

--- a/Tests/MushafImadSPMTests/MushafImadSPMTests.swift
+++ b/Tests/MushafImadSPMTests/MushafImadSPMTests.swift
@@ -1,5 +1,5 @@
 import Testing
-@testable import MushafImadSPM
+@testable import MushafImad
 
 @Test func example() async throws {
     // Write your test here and use APIs like `#expect(...)` to check expected conditions.


### PR DESCRIPTION
- Added `@unchecked Sendable` conformance to `UIImage` and `NSImage` to ensure safe usage across concurrency boundaries.
- Updated test import statement to reference `MushafImad` directly instead of `MushafImadSPM` for improved clarity.