### PR TITLE
Fix dark mode contrast in MushafView

### DIFF
--- a/Sources/MushafImad/MushafView.swift
+++ b/Sources/MushafImad/MushafView.swift
@@ -110,7 +110,7 @@ public struct MushafView: View {
                 LoadingView(message: viewModel.isLoading ? String(localized: "Loading Quran data...") : String(localized: "Preparing page..."))
             } else {
                 pageView
-                    .foregroundStyle(.naturalBlack)
+                    .foregroundStyle(.primary)
                 
             }
         }


### PR DESCRIPTION
## Summary
Fixes the dark mode contrast issue in the main MushafView by using semantic colors.

## Changes
Replaced `.naturalBlack` with `.primary` for the page view foreground style:

```swift
// Before
pageView
    .foregroundStyle(.naturalBlack)

// After
pageView
    .foregroundStyle(.primary)
```

## Why
When `readingTheme` is `.night`, the color scheme is set to `.dark` via:
```swift
.environment(\.colorScheme, readingTheme == .night ? .dark : .light)
```

Using `.primary` allows SwiftUI to automatically choose the appropriate text color (white on dark background) instead of the hardcoded `.naturalBlack` which doesn't adapt to the theme.

## Testing
1. Set the app to Night reading theme
2. Verify text is readable with good contrast
3. Switch between Light/Dark themes - text should remain readable

Fixes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated page content color rendering to use the primary color scheme instead of the previous natural black styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->