### PR TITLE
Refactor: Move reciter IDs to JSON manifest

### DIFF
--- a/Sources/MushafImad/AudioPlayer/Services/ReciterService.swift
+++ b/Sources/MushafImad/AudioPlayer/Services/ReciterService.swift
@@ -66,16 +66,33 @@ public final class ReciterService: ObservableObject {
         loadAvailableRecitersSync()
     }
     
+    /// Loads the list of available reciter IDs from the reciters_manifest.json file.
+    private func loadReciterManifest() -> [ReciterInfo] {
+        guard let url = Bundle.module.url(forResource: "reciters_manifest", withExtension: "json", subdirectory: "Res"),
+              let data = try? Data(contentsOf: url) else {
+            AppLogger.shared.warn("ReciterService: Could not load reciters_manifest.json", category: .network)
+            return []
+        }
+        
+        do {
+            let decoder = JSONDecoder()
+            return try decoder.decode([ReciterInfo].self, from: data)
+        } catch {
+            AppLogger.shared.error("ReciterService: Failed to decode reciters_manifest.json: \(error)", category: .network)
+            return []
+        }
+    }
+    
     private func loadAvailableRecitersSync() {
         var reciters: [ReciterInfo] = []
         
-        // List of available reciter IDs based on JSON files
-        let reciterIds = [1, 5, 9, 10, 31, 32, 51, 53, 60, 62, 67, 74, 78, 106, 112, 118, 159, 256]
+        // Load reciter IDs from JSON manifest
+        let manifestReciters = loadReciterManifest()
         
-        // Try to load from JSON files first
-        var loadedFromJSON = false
-        for id in reciterIds {
-            if let reciterTiming = AyahTimingService.shared.getReciter(id: id) {
+        // Try to load detailed timing data from individual JSON files first
+        var loadedFromTimingFiles = false
+        for manifestReciter in manifestReciters {
+            if let reciterTiming = AyahTimingService.shared.getReciter(id: manifestReciter.id) {
                 let info = ReciterInfo(
                     id: reciterTiming.id,
                     nameArabic: reciterTiming.name,
@@ -84,22 +101,28 @@ public final class ReciterService: ObservableObject {
                     folderURL: reciterTiming.folder_url
                 )
                 reciters.append(info)
-                loadedFromJSON = true
+                loadedFromTimingFiles = true
             }
         }
         
-        // If no reciters loaded from JSON, use the embedded data as fallback
-        if !loadedFromJSON {
-            AppLogger.shared.warn("ReciterService: No reciters loaded from JSON files, using embedded fallback data", category: .network)
-            for reciterData in ReciterDataProvider.reciters {
-                let info = ReciterInfo(
-                    id: reciterData.id,
-                    nameArabic: reciterData.nameArabic,
-                    nameEnglish: reciterData.nameEnglish,
-                    rewaya: reciterData.rewaya,
-                    folderURL: reciterData.folderURL
-                )
-                reciters.append(info)
+        // If no reciters loaded from timing files, use the manifest data directly
+        if !loadedFromTimingFiles {
+            if !manifestReciters.isEmpty {
+                AppLogger.shared.info("ReciterService: Using manifest data (no timing files found)", category: .network)
+                reciters = manifestReciters
+            } else {
+                // Last resort: use ReciterDataProvider as fallback
+                AppLogger.shared.warn("ReciterService: No manifest or timing files found, using embedded fallback data", category: .network)
+                for reciterData in ReciterDataProvider.reciters {
+                    let info = ReciterInfo(
+                        id: reciterData.id,
+                        nameArabic: reciterData.nameArabic,
+                        nameEnglish: reciterData.nameEnglish,
+                        rewaya: reciterData.rewaya,
+                        folderURL: reciterData.folderURL
+                    )
+                    reciters.append(info)
+                }
             }
         }
         

--- a/Sources/MushafImad/Resources/Res/reciters_manifest.json
+++ b/Sources/MushafImad/Resources/Res/reciters_manifest.json
@@ -1,0 +1,128 @@
+[
+    {
+        "id": 1,
+        "nameArabic": "إبراهيم الأخضر",
+        "nameEnglish": "Ibrahim Al-Akdar",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server6.mp3quran.net/akdr/"
+    },
+    {
+        "id": 5,
+        "nameArabic": "أحمد بن علي العجمي",
+        "nameEnglish": "Ahmad Al-Ajmy",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server10.mp3quran.net/ajm/"
+    },
+    {
+        "id": 9,
+        "nameArabic": "محمود خليل الحصري",
+        "nameEnglish": "Mahmoud Khalil Al-Hussary",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server13.mp3quran.net/husr/"
+    },
+    {
+        "id": 10,
+        "nameArabic": "علي بن عبدالرحمن الحذيفي",
+        "nameEnglish": "Ali Abdur-Rahman al-Huthaify",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server14.mp3quran.net/hthfi/"
+    },
+    {
+        "id": 31,
+        "nameArabic": "سعود الشريم",
+        "nameEnglish": "Saud Al-Shuraim",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server7.mp3quran.net/shur/"
+    },
+    {
+        "id": 32,
+        "nameArabic": "عبدالرحمن السديس",
+        "nameEnglish": "Abdul Rahman Al-Sudais",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server11.mp3quran.net/sds/"
+    },
+    {
+        "id": 51,
+        "nameArabic": "بندر بليلة",
+        "nameEnglish": "Bandar Baleela",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server7.mp3quran.net/balilah/"
+    },
+    {
+        "id": 53,
+        "nameArabic": "ياسر الدوسري",
+        "nameEnglish": "Yasser Al-Dosari",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server11.mp3quran.net/dosri/"
+    },
+    {
+        "id": 60,
+        "nameArabic": "فارس عباد",
+        "nameEnglish": "Fares Abbad",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server8.mp3quran.net/frs_a/"
+    },
+    {
+        "id": 62,
+        "nameArabic": "ماهر المعيقلي",
+        "nameEnglish": "Maher Al Mueaqly",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server12.mp3quran.net/maher/"
+    },
+    {
+        "id": 67,
+        "nameArabic": "عبدالله بصفر",
+        "nameEnglish": "Abdullah Basfar",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server7.mp3quran.net/basit/"
+    },
+    {
+        "id": 74,
+        "nameArabic": "ناصر القطامي",
+        "nameEnglish": "Nasser Al Qatami",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server6.mp3quran.net/qtm/"
+    },
+    {
+        "id": 78,
+        "nameArabic": "محمد أيوب",
+        "nameEnglish": "Muhammad Ayyub",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server16.mp3quran.net/ayyub2/"
+    },
+    {
+        "id": 106,
+        "nameArabic": "عمر القزابري",
+        "nameEnglish": "Omar Al-Qazabri",
+        "rewaya": "ورش عن نافع",
+        "folderURL": "https://server9.mp3quran.net/omar_warsh/"
+    },
+    {
+        "id": 112,
+        "nameArabic": "مشاري العفاسي",
+        "nameEnglish": "Mishari Rashid al-`Afasy",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server8.mp3quran.net/afs/"
+    },
+    {
+        "id": 118,
+        "nameArabic": "محمد جبريل",
+        "nameEnglish": "Mohammad al Tablaway",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server8.mp3quran.net/jbrl/"
+    },
+    {
+        "id": 159,
+        "nameArabic": "عبدالباسط عبدالصمد",
+        "nameEnglish": "Abdul Basit Abdus Samad",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server7.mp3quran.net/basit_mjwd/"
+    },
+    {
+        "id": 256,
+        "nameArabic": "هاني الرفاعي",
+        "nameEnglish": "Hani Ar-Rifai",
+        "rewaya": "حفص عن عاصم",
+        "folderURL": "https://server8.mp3quran.net/hani/"
+    }
+]


### PR DESCRIPTION
## Summary
Moved the hardcoded reciter IDs array from `ReciterService.swift` to a new `reciters_manifest.json` file.

## Changes
### New File: `reciters_manifest.json`
Created a JSON file in `Sources/MushafImad/Resources/Res/` containing all 18 reciter entries with their:
- `id`
- `nameArabic`
- `nameEnglish`
- `rewaya`
- `folderURL`

### Updated: `ReciterService.swift`
- Added `loadReciterManifest()` method to load and decode the JSON file using `Bundle.module`
- Updated `loadAvailableRecitersSync()` to use manifest data as the primary source
- Maintained `ReciterDataProvider` as a last-resort fallback for backwards compatibility

## Benefits
- **Configuration over code**: Adding new reciters no longer requires code changes
- **Contributor-friendly**: Non-developers can easily add reciters by editing JSON
- **Clear separation**: Data is separated from business logic
- **Maintainable**: Easy to audit and update reciter list

## Technical Notes
- Uses `Bundle.module.url(forResource:withExtension:subdirectory:)` for Swift Package resource access
- Uses `JSONDecoder` with the existing `ReciterInfo` type (already `Codable`)
- Falls back gracefully if JSON file is missing or malformed

## Testing
1. Build the package successfully
2. Run the Example app
3. Verify reciters load correctly in the picker
4. Audio playback should work as before

Fixes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved reciter data management by transitioning to external manifest-based loading, enabling future updates to reciter information without requiring app updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->