### PR TITLE
feat: support rendering Mushaf pages using 1405 layout

### DIFF
--- a/Sources/MushafImad/Core/Models/Chapter.swift
+++ b/Sources/MushafImad/Core/Models/Chapter.swift
@@ -33,11 +33,13 @@ public final class Chapter: Object, Identifiable {
         return ["number", "searchableText"]
     }
     
-    // Computed properties for compatibility with existing code
+    // Compatibility accessors — prefer startPage(for:)/endPage(for:) in layout-aware code
+    @available(*, deprecated, message: "Use startPage(for:) with an explicit MushafType")
     public var startPage: Int {
         startPage(for: .hafs1441)
     }
 
+    @available(*, deprecated, message: "Use endPage(for:) with an explicit MushafType")
     public var endPage: Int {
         endPage(for: .hafs1441)
     }

--- a/Sources/MushafImad/Core/Models/Chapter.swift
+++ b/Sources/MushafImad/Core/Models/Chapter.swift
@@ -35,17 +35,23 @@ public final class Chapter: Object, Identifiable {
     
     // Computed properties for compatibility with existing code
     public var startPage: Int {
-        // Get first verse's page number
-        guard let firstVerse = verses.first,
-              let page1441 = firstVerse.page1441 else { return 604 }
-        return page1441.number
+        startPage(for: .hafs1441)
     }
-    
+
     public var endPage: Int {
-        // Get last verse's page number
+        endPage(for: .hafs1441)
+    }
+
+    public func startPage(for mushafType: MushafType) -> Int {
+        guard let firstVerse = verses.first,
+              let page = firstVerse.page(for: mushafType) else { return 604 }
+        return page.number
+    }
+
+    public func endPage(for mushafType: MushafType) -> Int {
         guard let lastVerse = verses.last,
-              let page1441 = lastVerse.page1441 else { return 1 }
-        return page1441.number
+              let page = lastVerse.page(for: mushafType) else { return 1 }
+        return page.number
     }
     
     public var versesCount: Int {

--- a/Sources/MushafImad/Core/Models/Chapter.swift
+++ b/Sources/MushafImad/Core/Models/Chapter.swift
@@ -60,9 +60,11 @@ public final class Chapter: Object, Identifiable {
         return verses.count > 0 ? verses.count : 286
     }
     
-    public var pagesCount: Int {
-        guard startPage > 0 && endPage > 0 else { return 0 }
-        return endPage - startPage + 1
+    public func pagesCount(for mushafType: MushafType) -> Int {
+        let start = startPage(for: mushafType)
+        let end = endPage(for: mushafType)
+        guard start > 0 && end > 0 else { return 0 }
+        return end - start + 1
     }
     
     public var displayTitle: String {

--- a/Sources/MushafImad/Core/Models/Page.swift
+++ b/Sources/MushafImad/Core/Models/Page.swift
@@ -22,9 +22,41 @@ public final class Page: Object {
     @objc nonisolated override public class func primaryKey() -> String? {
         return "identifier"
     }
-    
+
     @objc nonisolated override public class func indexedProperties() -> [String] {
         return ["number"]
+    }
+
+    /// Returns the verses list for the given Mushaf layout.
+    public func verses(for mushafType: MushafType) -> [Verse] {
+        switch mushafType {
+        case .hafs1441: return Array(verses1441)
+        case .hafs1405: return Array(verses1405)
+        }
+    }
+
+    /// Returns chapter headers for the given Mushaf layout.
+    public func chapterHeaders(for mushafType: MushafType) -> [ChapterHeader] {
+        switch mushafType {
+        case .hafs1441: return Array(chapterHeaders1441)
+        case .hafs1405: return Array(chapterHeaders1405)
+        }
+    }
+
+    /// Returns the page header for the given Mushaf layout.
+    public func header(for mushafType: MushafType) -> PageHeader? {
+        switch mushafType {
+        case .hafs1441: return header1441
+        case .hafs1405: return header1405
+        }
+    }
+
+    /// Whether this page has image-rendering data for the given layout.
+    public func hasImageData(for mushafType: MushafType) -> Bool {
+        let v = verses(for: mushafType)
+        guard !v.isEmpty else { return false }
+        // Check if at least some verses have markers (line-level data)
+        return v.contains { $0.marker(for: mushafType) != nil }
     }
 }
 

--- a/Sources/MushafImad/Core/Models/Verse.swift
+++ b/Sources/MushafImad/Core/Models/Verse.swift
@@ -42,6 +42,30 @@ public final class Verse: Object, Identifiable {
     public var chapterNumber: Int {
         return chapter?.number ?? 0
     }
+
+    /// Returns the page for the given Mushaf layout.
+    public func page(for mushafType: MushafType) -> Page? {
+        switch mushafType {
+        case .hafs1441: return page1441
+        case .hafs1405: return page1405
+        }
+    }
+
+    /// Returns the verse marker for the given Mushaf layout.
+    public func marker(for mushafType: MushafType) -> VerseMarker? {
+        switch mushafType {
+        case .hafs1441: return marker1441
+        case .hafs1405: return marker1405
+        }
+    }
+
+    /// Returns the highlight regions for the given Mushaf layout.
+    public func highlights(for mushafType: MushafType) -> List<VerseHighlight> {
+        switch mushafType {
+        case .hafs1441: return highlights1441
+        case .hafs1405: return highlights1405
+        }
+    }
 }
 
 extension Verse {

--- a/Sources/MushafImad/Core/Services/QuranDataCacheService.swift
+++ b/Sources/MushafImad/Core/Services/QuranDataCacheService.swift
@@ -57,15 +57,15 @@ public final class QuranDataCacheService {
     }
     
     /// Pre-fetch and cache data for a specific chapter
-    public func cacheChapterData(_ chapter: Chapter) async {
+    public func cacheChapterData(_ chapter: Chapter, mushafType: MushafType = .hafs1441) async {
         // Cache chapter verses
         let verses = realmService.getVersesForChapter(chapter.number)
         if !verses.isEmpty {
             cachedChapterVerses[chapter.number] = verses
         }
-        
+
         // Cache all pages in this chapter
-        await cachePageRange(chapter.startPage...chapter.endPage)
+        await cachePageRange(chapter.startPage(for: mushafType)...chapter.endPage(for: mushafType))
     }
     
     // MARK: - Cache Retrieval
@@ -91,11 +91,11 @@ public final class QuranDataCacheService {
     }
     
     /// Check if chapter data is fully cached
-    public func isChapterCached(_ chapter: Chapter) -> Bool {
+    public func isChapterCached(_ chapter: Chapter, mushafType: MushafType = .hafs1441) -> Bool {
         guard cachedChapterVerses[chapter.number] != nil else { return false }
-        
+
         // Check if all pages are cached
-        for pageNumber in chapter.startPage...chapter.endPage {
+        for pageNumber in chapter.startPage(for: mushafType)...chapter.endPage(for: mushafType) {
             if !isPageCached(pageNumber) {
                 return false
             }

--- a/Sources/MushafImad/Core/Services/RealmService.swift
+++ b/Sources/MushafImad/Core/Services/RealmService.swift
@@ -164,20 +164,20 @@ public final class RealmService: RealmServiceProtocol {
         return realm?.objects(Chapter.self).filter("number == %@", number).first?.freeze()
     }
     
-    public func getChapterForPage(_ pageNumber: Int) -> Chapter? {
+    public func getChapterForPage(_ pageNumber: Int, mushafType: MushafType = .hafs1441) -> Chapter? {
         // Get page and find first chapter that appears on it
         guard let page = getPage(number: pageNumber) else { return nil }
-        
+
         // Check if page has chapter headers (new chapters starting on this page)
-        if let firstHeader = page.chapterHeaders1441.first {
+        if let firstHeader = page.chapterHeaders(for: mushafType).first {
             return firstHeader.chapter?.freeze()
         }
-        
+
         // Otherwise, get the chapter of the first verse on the page
-        if let firstVerse = page.verses1441.first {
+        if let firstVerse = page.verses(for: mushafType).first {
             return firstVerse.chapter?.freeze()
         }
-        
+
         return nil
     }
     
@@ -222,13 +222,7 @@ public final class RealmService: RealmServiceProtocol {
     
     public func getPageHeader(for pageNumber: Int, mushafType: MushafType = .hafs1441) -> PageHeader? {
         guard let page = getPage(number: pageNumber) else { return nil }
-        
-        switch mushafType {
-        case .hafs1441:
-            return page.header1441
-        case .hafs1405:
-            return page.header1405
-        }
+        return page.header(for: mushafType)
     }
     
     public func getPageHeaderInfo(for pageNumber: Int, mushafType: MushafType = .hafs1441) -> PageHeaderInfo? {
@@ -256,13 +250,7 @@ public final class RealmService: RealmServiceProtocol {
     
     public func getVersesForPage(_ pageNumber: Int, mushafType: MushafType = .hafs1441) -> [Verse] {
         guard let page = getPage(number: pageNumber) else { return [] }
-        
-        switch mushafType {
-        case .hafs1441:
-            return Array(page.verses1441.freeze())
-        case .hafs1405:
-            return Array(page.verses1405.freeze())
-        }
+        return page.verses(for: mushafType).map { $0.freeze() }
     }
     
     public func getVersesForChapter(_ chapterNumber: Int) -> [Verse] {
@@ -295,9 +283,9 @@ public final class RealmService: RealmServiceProtocol {
         return realm?.objects(Part.self).filter("number == %@", number).first?.freeze()
     }
     
-    public func getPartForPage(_ pageNumber: Int) -> Part? {
+    public func getPartForPage(_ pageNumber: Int, mushafType: MushafType = .hafs1441) -> Part? {
         guard let page = getPage(number: pageNumber) else { return nil }
-        return page.header1441?.part?.freeze()
+        return page.header(for: mushafType)?.part?.freeze()
     }
     
     public func getPartForVerse(chapterNumber: Int, verseNumber: Int) -> Part? {
@@ -336,9 +324,9 @@ public final class RealmService: RealmServiceProtocol {
             .filter("hizbNumber == %@ AND hizbFraction == %@", hizbNumber, fraction).first?.freeze()
     }
     
-    public func getQuarterForPage(_ pageNumber: Int) -> Quarter? {
+    public func getQuarterForPage(_ pageNumber: Int, mushafType: MushafType = .hafs1441) -> Quarter? {
         guard let page = getPage(number: pageNumber) else { return nil }
-        return page.header1441?.quarter?.freeze()
+        return page.header(for: mushafType)?.quarter?.freeze()
     }
     
     public func getQuarterForVerse(chapterNumber: Int, verseNumber: Int) -> Quarter? {
@@ -417,25 +405,25 @@ public final class RealmService: RealmServiceProtocol {
     
     // MARK: - Utility Methods
     
-    public func getChaptersOnPage(_ pageNumber: Int) -> [Chapter] {
+    public func getChaptersOnPage(_ pageNumber: Int, mushafType: MushafType = .hafs1441) -> [Chapter] {
         guard let page = getPage(number: pageNumber) else { return [] }
-        
+
         var chapters: Set<Chapter> = []
-        
+
         // Add chapters from headers (new chapters starting on this page)
-        for header in page.chapterHeaders1441 {
+        for header in page.chapterHeaders(for: mushafType) {
             if let chapter = header.chapter {
                 chapters.insert(chapter)
             }
         }
-        
+
         // Add chapters from verses
-        for verse in page.verses1441 {
+        for verse in page.verses(for: mushafType) {
             if let chapter = verse.chapter {
                 chapters.insert(chapter)
             }
         }
-        
+
         return Array(chapters).sorted { $0.number < $1.number }.map { $0.freeze() }
     }
     
@@ -464,9 +452,18 @@ public final class RealmService: RealmServiceProtocol {
 // MARK: - Supporting Types
 
 /// Supported Mushaf layouts that alter how verses map to pages.
-public enum MushafType {
+public enum MushafType: String, CaseIterable {
     case hafs1441  // Modern layout
     case hafs1405  // Traditional layout
+
+    public var title: String {
+        switch self {
+        case .hafs1441:
+            return String(localized: "1441")
+        case .hafs1405:
+            return String(localized: "1405")
+        }
+    }
 }
 
 // MARK: - Page Header Info Structure

--- a/Sources/MushafImad/Mushaf-Search/MushafSearch.swift
+++ b/Sources/MushafImad/Mushaf-Search/MushafSearch.swift
@@ -136,10 +136,11 @@ struct VerseResultRow: View {
 struct ChapterResultRow: View {
     let chapter: Chapter
     @State private var navbarHidden: Bool = true
+    @AppStorage("mushaf_type") private var mushafType: MushafType = .hafs1441
 
     var body: some View {
         NavigationLink {
-            MushafView(initialPage: chapter.startPage, onPageTap: {
+            MushafView(initialPage: chapter.startPage(for: mushafType), onPageTap: {
                 withAnimation {
                     navbarHidden.toggle()
                 }

--- a/Sources/MushafImad/MushafView.swift
+++ b/Sources/MushafImad/MushafView.swift
@@ -86,6 +86,7 @@ public struct MushafView: View {
     @AppStorage("reading_theme") private var readingTheme: ReadingTheme = .white
     @AppStorage("scrolling_mode") private var scrollingMode: ScrollingMode = .horizontal
     @AppStorage("display_mode") private var displayMode: DisplayMode = .text
+    @AppStorage("mushaf_type") private var mushafType: MushafType = .hafs1441
     @AppStorage("text_font_size") private var textFontSize: Double = 24.0
     @State private var textModeInitialChapter: Int = 1
 
@@ -255,10 +256,19 @@ public struct MushafView: View {
         }
     }
 
+    /// Whether the current Mushaf type supports image-based rendering.
+    /// The 1405 layout currently lacks line images, so it falls back to text mode.
+    private var effectiveDisplayMode: DisplayMode {
+        if displayMode == .image && mushafType == .hafs1405 {
+            return .text
+        }
+        return displayMode
+    }
+
     // MARK: - View Components
     @ViewBuilder
     private var toolbarButtons: some View {
-        if displayMode == .text {
+        if effectiveDisplayMode == .text {
             Menu {
                 ForEach([16.0, 20.0, 24.0, 28.0, 32.0, 36.0], id: \.self) { size in
                     Button {
@@ -275,6 +285,22 @@ public struct MushafView: View {
                 Image(systemName: "textformat.size")
             }
         }
+        // Mushaf type picker
+        Menu {
+            ForEach(MushafType.allCases, id: \.self) { type in
+                Button {
+                    mushafType = type
+                } label: {
+                    if mushafType == type {
+                        Label(type.title, systemImage: "checkmark")
+                    } else {
+                        Text(type.title)
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "book.closed")
+        }
         Button {
             displayMode = (displayMode == .image) ? .text : .image
         } label: {
@@ -287,9 +313,9 @@ public struct MushafView: View {
         let currentHighlight = playingVerse
         ?? highlightedVerseBinding?.wrappedValue
         ?? staticHighlightedVerse
-        
+
         Group {
-            if displayMode == .text {
+            if effectiveDisplayMode == .text {
                 MushafTextView(
                     initialChapter: textModeInitialChapter,
                     highlightedVerse: currentHighlight,
@@ -386,6 +412,7 @@ public struct MushafView: View {
     public func pageContent(for pageNumber: Int, highlight: Verse?) -> some View {
         PageContainer(
             pageNumber: pageNumber,
+            mushafType: mushafType,
             highlightedVerse: highlight,
             selectedVerse: $viewModel.selectedVerse,
             onVerseLongPress: { verse in

--- a/Sources/MushafImad/MushafView.swift
+++ b/Sources/MushafImad/MushafView.swift
@@ -194,7 +194,7 @@ public struct MushafView: View {
                    let baseURL = reciter.audioBaseURL,
                    let target = viewModel.nextChapter(from: playerViewModel.chapterNumber) {
                     withAnimation {
-                        viewModel.navigateToChapterAndPrepareScroll(target)
+                        viewModel.navigateToChapterAndPrepareScroll(target, mushafType: mushafType)
                     }
                     playerViewModel.configureIfNeeded(
                         baseURL: baseURL,

--- a/Sources/MushafImad/MushafView.swift
+++ b/Sources/MushafImad/MushafView.swift
@@ -155,16 +155,22 @@ public struct MushafView: View {
             await viewModel.initializePageView(initialPage: initialPage)
         }
         .onAppear {
-            if displayMode == .text {
+            if effectiveDisplayMode == .text {
                 let page = viewModel.scrollPosition ?? initialPage ?? 1
-                textModeInitialChapter = RealmService.shared.getChapterForPage(page)?.number ?? 1
+                textModeInitialChapter = RealmService.shared.getChapterForPage(page, mushafType: mushafType)?.number ?? 1
             }
         }
         .onChange(of: displayMode) { _, newMode in
             if newMode == .text {
                 let page = viewModel.scrollPosition ?? initialPage ?? 1
-                textModeInitialChapter = RealmService.shared.getChapterForPage(page)?.number ?? 1
+                textModeInitialChapter = RealmService.shared.getChapterForPage(page, mushafType: mushafType)?.number ?? 1
             }
+        }
+        .onChange(of: mushafType) { _, newType in
+            let willRenderText = displayMode == .text || (displayMode == .image && newType == .hafs1405)
+            guard willRenderText else { return }
+            let page = viewModel.scrollPosition ?? initialPage ?? 1
+            textModeInitialChapter = RealmService.shared.getChapterForPage(page, mushafType: newType)?.number ?? 1
         }
         .toolbar {
             #if os(iOS) || os(visionOS)

--- a/Sources/MushafImad/PageContainer.swift
+++ b/Sources/MushafImad/PageContainer.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// Thin wrapper that loads a `Page` model, then renders it via `QuranPageView`.
 public struct PageContainer: View {
     public let pageNumber: Int
+    public let mushafType: MushafType
     public let highlightedVerse: Verse?
     @Binding public var selectedVerse: Verse?
     public let onVerseLongPress: (Verse) -> Void
@@ -22,12 +23,14 @@ public struct PageContainer: View {
 
     public init(
         pageNumber: Int,
+        mushafType: MushafType = .hafs1441,
         highlightedVerse: Verse?,
         selectedVerse: Binding<Verse?>,
         onVerseLongPress: @escaping (Verse) -> Void,
         onTap: @escaping () -> Void
     ) {
         self.pageNumber = pageNumber
+        self.mushafType = mushafType
         self.highlightedVerse = highlightedVerse
         self._selectedVerse = selectedVerse
         self.onVerseLongPress = onVerseLongPress
@@ -41,11 +44,12 @@ public struct PageContainer: View {
                     QuranPageView(
                         pageNumber: pageNumber,
                         page: pageData,
-                        initialHighlightedVerse: highlightedVerse?.page1441?.number == pageNumber ? highlightedVerse : nil,
+                        mushafType: mushafType,
+                        initialHighlightedVerse: highlightedVerse?.page(for: mushafType)?.number == pageNumber ? highlightedVerse : nil,
                         selectedVerse: $selectedVerse,
                         onVerseLongPress: onVerseLongPress,
                         header: {
-                            PageHeaderView(page: pageData)
+                            PageHeaderView(page: pageData, mushafType: mushafType)
                         },
                         footer: {
                             PageFooterView(pageNumber: pageData.number, isRight: pageData.isRight)

--- a/Sources/MushafImad/PageHeaderView.swift
+++ b/Sources/MushafImad/PageHeaderView.swift
@@ -9,10 +9,12 @@ import SwiftUI
 
 public struct PageHeaderView: View {
     public let page: Page
+    public let mushafType: MushafType
     public var horizentalPadding: CGFloat = 16
-    
-    public init(page: Page, horizentalPadding: CGFloat = 16) {
+
+    public init(page: Page, mushafType: MushafType = .hafs1441, horizentalPadding: CGFloat = 16) {
         self.page = page
+        self.mushafType = mushafType
         self.horizentalPadding = horizentalPadding
     }
     
@@ -46,8 +48,7 @@ public struct PageHeaderView: View {
     }
     
     public func getPageHeaderDisplay(page: Page) -> (juz: String?, hizb: HizbDisplayInfo?, titles: [String]) {
-        // Get the header for the current Mushaf type (defaulting to 1441)
-        guard let header = page.header1441 else {
+        guard let header = page.header(for: mushafType) else {
             return (nil, nil, [])
         }
         let titles:[String] = header.chapters.map { $0.arabicTitle }

--- a/Sources/MushafImad/PlayerViewUI.swift
+++ b/Sources/MushafImad/PlayerViewUI.swift
@@ -10,6 +10,7 @@ import SwiftUI
 public struct PlayerViewUI: View {
     @EnvironmentObject private var reciterService: ReciterService
     @StateObject private var playerViewModel = QuranPlayerViewModel()
+    @AppStorage("mushaf_type") private var mushafType: MushafType = .hafs1441
 
     public let chapter: Chapter
     public let viewModel: MushafView.ViewModel
@@ -88,7 +89,7 @@ public struct PlayerViewUI: View {
         previewVerse: Int
     ) {
         let wasPlaying = playerViewModel.isPlaying
-        withAnimation { viewModel.navigateToChapterAndPrepareScroll(target) }
+        withAnimation { viewModel.navigateToChapterAndPrepareScroll(target, mushafType: mushafType) }
         playerViewModel.configureIfNeeded(
             baseURL: baseURL,
             chapterNumber: target.number,

--- a/Sources/MushafImad/QuranPageView.swift
+++ b/Sources/MushafImad/QuranPageView.swift
@@ -27,20 +27,22 @@ public struct SelectedVerseRectKey: PreferenceKey {
 public struct QuranPageView<Header: View, Footer: View>: View {
     public let pageNumber: Int
     public var page: Page
+    public let mushafType: MushafType
     public let initialHighlightedVerse: Verse?
     @Binding public var selectedVerse: Verse?
-    
+
     public var onVerseLongPress: ((Verse) -> Void)? = nil
-    
+
     private let headerBuilder: () -> Header
     private let footerBuilder: () -> Footer
-    
+
     // State to track which verse is currently being pressed (shared across all lines)
     @State private var pressingVerseID: Int? = nil
-    
+
     public init(
         pageNumber: Int,
         page: Page,
+        mushafType: MushafType = .hafs1441,
         initialHighlightedVerse: Verse?,
         selectedVerse: Binding<Verse?>,
         onVerseLongPress: ((Verse) -> Void)? = nil,
@@ -49,6 +51,7 @@ public struct QuranPageView<Header: View, Footer: View>: View {
     ) {
         self.pageNumber = pageNumber
         self.page = page
+        self.mushafType = mushafType
         self.initialHighlightedVerse = initialHighlightedVerse
         self._selectedVerse = selectedVerse
         self.onVerseLongPress = onVerseLongPress
@@ -76,9 +79,10 @@ public struct QuranPageView<Header: View, Footer: View>: View {
                         ForEach(0...14,id: \.self) { line in
                             LineImageView(
                                 pageNumber: pageNumber,
-                                chapterheader: Array(page.chapterHeaders1441),
+                                mushafType: mushafType,
+                                chapterheader: page.chapterHeaders(for: mushafType),
                                 line: line,
-                                verses: Array(page.verses1441),
+                                verses: page.verses(for: mushafType),
                                 container: CGSize(width: availableWidth, height: lineHeight),
                                 selectedVerse: selectedVerse,
                                 highlightedVerse: initialHighlightedVerse,
@@ -104,9 +108,10 @@ public struct QuranPageView<Header: View, Footer: View>: View {
                     ForEach(0...14,id: \.self) { line in
                         LineImageView(
                             pageNumber: pageNumber,
-                            chapterheader: Array(page.chapterHeaders1441),
+                            mushafType: mushafType,
+                            chapterheader: page.chapterHeaders(for: mushafType),
                             line: line,
-                            verses: Array(page.verses1441),
+                            verses: page.verses(for: mushafType),
                             container: CGSize(width: availableWidth, height: availableHeight),
                             selectedVerse: selectedVerse,
                             highlightedVerse: initialHighlightedVerse,
@@ -147,6 +152,7 @@ public struct QuranPageView<Header: View, Footer: View>: View {
 // MARK: - Line Image View
 private struct LineImageView: View {
     let pageNumber: Int
+    let mushafType: MushafType
     let chapterheader: [ChapterHeader]
     let line: Int
     let verses: [Verse]
@@ -173,7 +179,7 @@ private struct LineImageView: View {
 
     @ViewBuilder
     private func verseHighlightsView(verse: Verse, geometry: GeometryProxy) -> some View {
-        ForEach(verse.highlights1441.filter({ $0.line == line }), id: \.self) { highlight in
+        ForEach(verse.highlights(for: mushafType).filter({ $0.line == line }), id: \.self) { highlight in
             let visualLeftX = geometry.size.width * CGFloat(1.0 - highlight.right)
             let visualRightX = geometry.size.width * CGFloat(1.0 - highlight.left)
             let highlightWidth = visualRightX - visualLeftX
@@ -233,7 +239,7 @@ private struct LineImageView: View {
                     verseHighlightsView(verse: verse, geometry: geometry)
                     
                     // Only render marker if it belongs to this line
-                    if let marker = verse.marker1441, marker.line == line {
+                    if let marker = verse.marker(for: mushafType), marker.line == line {
                         let markerX = geometry.size.width * CGFloat(1.0 - marker.centerX)
                         
                         let fullImageY = scaledImageHeight * CGFloat(marker.centerY)

--- a/Sources/MushafImad/Services/MushafView+ViewModel.swift
+++ b/Sources/MushafImad/Services/MushafView+ViewModel.swift
@@ -254,29 +254,17 @@ extension MushafView {
             if let cachedVerses = dataCache.getCachedVerses(forPage: currentPage) {
                 return cachedVerses
             }
-            
+
             // Fall back to Realm
             guard let page = currentPageObject else { return [] }
-            
-            switch mushafType {
-            case .hafs1441:
-                return Array(page.verses1441)
-            case .hafs1405:
-                return Array(page.verses1405)
-            }
+            return page.verses(for: mushafType)
         }
-        
+
         /// Get chapter headers for the current page directly from Page object
         /// Access the header overlays for the current page for layout decisions.
         public func getChapterHeadersForCurrentPage(mushafType: MushafType = .hafs1441) -> [ChapterHeader] {
             guard let page = currentPageObject else { return [] }
-            
-            switch mushafType {
-            case .hafs1441:
-                return Array(page.chapterHeaders1441)
-            case .hafs1405:
-                return Array(page.chapterHeaders1405)
-            }
+            return page.chapterHeaders(for: mushafType)
         }
         
         /// Check if current page is a right page

--- a/Sources/MushafImad/Services/MushafView+ViewModel.swift
+++ b/Sources/MushafImad/Services/MushafView+ViewModel.swift
@@ -125,14 +125,14 @@ extension MushafView {
         
         @MainActor
         /// Derive the active chapter for a given page, keeping UI metadata in sync.
-        public func updateCurrentChapter(for page: Int) {
+        public func updateCurrentChapter(for page: Int, mushafType: MushafType = .hafs1441) {
             currentChapter = chapters.first { chapter in
-                page >= chapter.startPage && page <= chapter.endPage
+                page >= chapter.startPage(for: mushafType) && page <= chapter.endPage(for: mushafType)
             }
         }
-        
-        public func navigateToChapter(_ chapter: Chapter) {
-            currentPage = chapter.startPage
+
+        public func navigateToChapter(_ chapter: Chapter, mushafType: MushafType = .hafs1441) {
+            currentPage = chapter.startPage(for: mushafType)
         }
         
         public func nextPage() {
@@ -152,9 +152,9 @@ extension MushafView {
         
         /// Navigate to chapter and set scroll position to its start page
         /// Jump to a chapter and update the scroll position so SwiftUI updates the pager.
-        public func navigateToChapterAndPrepareScroll(_ chapter: Chapter) {
-            navigateToChapter(chapter)
-            scrollPosition = chapter.startPage
+        public func navigateToChapterAndPrepareScroll(_ chapter: Chapter, mushafType: MushafType = .hafs1441) {
+            navigateToChapter(chapter, mushafType: mushafType)
+            scrollPosition = chapter.startPage(for: mushafType)
         }
         
         @MainActor


### PR DESCRIPTION
## Summary

- Makes the entire rendering pipeline **MushafType-aware**, replacing all hardcoded `1441` references with dynamic accessors
- Adds convenience methods on `Page` and `Verse` models: `page.verses(for:)`, `verse.marker(for:)`, `verse.highlights(for:)`, etc.
- Adds a **Mushaf type picker** (1441/1405) in the toolbar, persisted via `@AppStorage`
- **Auto-fallback to text mode** when 1405 is selected, since line images are not yet available — when 1405 line images are added in the future, image mode will work automatically

### Files changed (9)

| File | Change |
|------|--------|
| `Page.swift` | Added `verses(for:)`, `chapterHeaders(for:)`, `header(for:)`, `hasImageData(for:)` |
| `Verse.swift` | Added `page(for:)`, `marker(for:)`, `highlights(for:)` |
| `Chapter.swift` | Made `startPage`/`endPage` MushafType-aware |
| `RealmService.swift` | Made `MushafType` conform to `String, CaseIterable`; updated all methods to use accessors |
| `QuranPageView.swift` | Accepts `mushafType`, passes to `LineImageView` |
| `PageContainer.swift` | Threads `mushafType` through to `QuranPageView` and `PageHeaderView` |
| `PageHeaderView.swift` | Reads header via `page.header(for: mushafType)` |
| `MushafView.swift` | Added `@AppStorage("mushaf_type")`, type picker in toolbar, auto text-mode fallback |
| `MushafView+ViewModel.swift` | Simplified to use `Page`/`Verse` accessors |

## Test plan

- [ ] Select 1441 in the toolbar picker — image mode renders as before (no regression)
- [ ] Select 1405 in the toolbar picker — automatically switches to text mode
- [ ] Switch back to 1441 — image mode is available again
- [ ] Verify page headers, verse markers, highlights all render correctly in 1441
- [ ] Verify text mode works for both 1441 and 1405 with correct chapter/verse display
- [ ] Verify the Mushaf type preference persists across app restarts

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mushaf type selector in the toolbar to switch between available Quran layouts.
  * UI now adapts displayed verses, chapter headers, page highlights and images to the selected Mushaf type.
  * Localized titles for Mushaf types shown in the UI.

* **Bug Fixes / Improvements**
  * Automatic fallback to text rendering when images aren’t available for the chosen layout.
  * Page/chapter navigation and highlighting now respect the selected Mushaf type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->