### PR TITLE
feat: add eye-tracking-assisted reading progress (#22)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -2,7 +2,7 @@ name: iOS Build & Test
 
 on:
   push:
-    branches: [ "main", "master" ]
+    branches: [ "main", "master", "feature/eye-tracking-reading-progress" ]
   pull_request:
     branches: [ "main", "master" ]
 

--- a/Example/Example/Info.plist
+++ b/Example/Example/Info.plist
@@ -15,5 +15,7 @@
 	<array>
 		<string>Kitab-Bold.ttf</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera access is used for eye tracking to follow your reading progress in the Quran.</string>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -83,6 +83,47 @@ A Swift Package that delivers a fully featured Mushaf (Quran) reading experience
 
 ## Using the Package
 
+### SwiftData Model Container Setup (Required for Eye Tracking)
+
+If you plan to use the **eye-tracking reading progress feature**, you must include the `ReadingSession` model in your app's SwiftData `ModelContainer` schema. This model persists reading sessions locally for progress tracking and resumption.
+
+**Add to your App initialization:**
+
+```swift
+import SwiftUI
+import SwiftData
+import MushafImad
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .modelContainer(for: [
+            ReadingSession.self  // Required for eye tracking persistence
+        ])
+    }
+}
+```
+
+**Why is this required?**
+- The `ReadingSession` model uses SwiftData's `@Model` macro for persistence
+- Apps that don't include it in their schema will crash at runtime when eye tracking attempts to save sessions
+- This is only needed if you enable the eye tracking feature
+
+**Migration for existing apps:**
+If your app already has a `ModelContainer`, simply add `ReadingSession.self` to your existing model array:
+
+```swift
+.modelContainer(for: [
+    YourExistingModel.self,
+    ReadingSession.self  // Add this
+])
+```
+
+### Basic Setup
+
 1. **Add the dependency**
 
    ```swift
@@ -109,6 +150,7 @@ A Swift Package that delivers a fully featured Mushaf (Quran) reading experience
                    .environmentObject(ReciterService.shared)
                    .environmentObject(ToastManager())
            }
+           .modelContainer(for: [ReadingSession.self])  // Required for eye tracking
        }
    }
    ```

--- a/Sources/MushafImad/Core/Models/ReadingSession.swift
+++ b/Sources/MushafImad/Core/Models/ReadingSession.swift
@@ -1,0 +1,91 @@
+//
+//  ReadingSession.swift
+//  MushafImad
+//
+//  SwiftData model to persist eye-tracking reading progress.
+//
+//  Created for Ramadan Impact — exploratory research (Issue #22).
+//
+
+import Foundation
+import SwiftData
+
+/// Records a reading session detected via eye tracking or heuristic estimation.
+/// Persisted locally via SwiftData for reading progress and resumption.
+@Model
+public final class ReadingSession {
+    @Attribute(.unique) public var id: UUID
+    
+    /// The page number where this session was recorded (1–604).
+    public var pageNumber: Int
+    
+    /// The last verse ID the user was reading when the session ended.
+    public var lastVerseID: Int
+    
+    /// The verse's chapter number for quick display.
+    public var chapterNumber: Int
+    
+    /// The verse number within its chapter.
+    public var verseNumber: Int
+    
+    /// The line index (0–14) where the user's gaze last rested.
+    public var lastLineIndex: Int
+    
+    /// When this reading session started.
+    public var startedAt: Date
+    
+    /// When this reading session was last updated (the user's gaze was last tracked).
+    public var lastUpdatedAt: Date
+    
+    /// Total active reading time in seconds (excluding pauses / face-lost).
+    public var activeReadingDuration: TimeInterval
+    
+    /// The method used for tracking.
+    public var trackingMethod: TrackingMethod
+    
+    /// Whether the user reached the end of the page naturally.
+    public var completedPage: Bool
+    
+    /// Average gaze confidence during this session (0.0–1.0).
+    public var averageConfidence: Float
+    
+    public init(
+        id: UUID = UUID(),
+        pageNumber: Int,
+        lastVerseID: Int,
+        chapterNumber: Int,
+        verseNumber: Int,
+        lastLineIndex: Int = 0,
+        startedAt: Date = .now,
+        lastUpdatedAt: Date = .now,
+        activeReadingDuration: TimeInterval = 0,
+        trackingMethod: TrackingMethod = .eyeTracking,
+        completedPage: Bool = false,
+        averageConfidence: Float = 0
+    ) {
+        self.id = id
+        self.pageNumber = pageNumber
+        self.lastVerseID = lastVerseID
+        self.chapterNumber = chapterNumber
+        self.verseNumber = verseNumber
+        self.lastLineIndex = lastLineIndex
+        self.startedAt = startedAt
+        self.lastUpdatedAt = lastUpdatedAt
+        self.activeReadingDuration = activeReadingDuration
+        self.trackingMethod = trackingMethod
+        self.completedPage = completedPage
+        self.averageConfidence = averageConfidence
+    }
+}
+
+/// The method used to track reading progress.
+public enum TrackingMethod: String, Codable {
+    /// Hardware eye tracking via ARKit TrueDepth camera.
+    case eyeTracking
+    
+    /// Heuristic-based estimation (scroll position + reading speed).
+    case heuristic
+    
+    /// Manual bookmark by the user.
+    case manual
+}

--- a/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
@@ -22,7 +22,7 @@ import SwiftData
 /// @StateObject private var eyeCoordinator = EyeTrackingCoordinator()
 /// // In your view body:
 /// .onAppear { eyeCoordinator.activate(pageNumber: 1, verses: [...], pageFrame: ...) }
-/// .onDisappear { eyeCoordinator.deactivate() }
+/// .onDisappear { eyeCoordinator.deactivate(context: modelContext) }
 /// ```
 @MainActor
 public final class EyeTrackingCoordinator: ObservableObject {
@@ -48,14 +48,18 @@ public final class EyeTrackingCoordinator: ObservableObject {
     @AppStorage("eye_tracking_enabled") public var isEnabled: Bool = false
     @AppStorage("eye_tracking_auto_highlight") private var autoHighlight: Bool = true
     
-    public func setEnabled(_ enabled: Bool) {
+    /// Enable or disable eye-tracking.
+    ///
+    /// Passing `context` when disabling ensures any buffered sessions are
+    /// flushed to SwiftData before the coordinator clears its state.
+    public func setEnabled(_ enabled: Bool, context: ModelContext? = nil) {
         isEnabled = enabled
         if enabled {
             if eyeTrackingService.isSupported && !useFallbackMode {
                 eyeTrackingService.startTracking()
             }
         } else {
-            deactivate()
+            deactivate(context: context)
         }
     }
     @AppStorage("eye_tracking_auto_advance") private var autoAdvance: Bool = false
@@ -217,6 +221,7 @@ public final class EyeTrackingCoordinator: ObservableObject {
     
     /// Pause tracking (app backgrounded, sheet presented, etc.).
     public func pause() {
+        progressTracker.pauseTracking()
         fallbackEstimator.pause()
         if eyeTrackingService.isSupported && !useFallbackMode {
             eyeTrackingService.stopTracking()
@@ -225,6 +230,7 @@ public final class EyeTrackingCoordinator: ObservableObject {
     
     /// Resume tracking after a pause.
     public func resume() {
+        progressTracker.resumeTracking()
         fallbackEstimator.resume()
         if eyeTrackingService.isSupported && !useFallbackMode {
             eyeTrackingService.startTracking()

--- a/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
@@ -167,20 +167,24 @@ public final class EyeTrackingCoordinator: ObservableObject {
         progressTracker.onPageCompleted = onPageCompleted
         
         // Start tracking
-        progressTracker.startTracking(
-            pageNumber: pageNumber,
-            verses: verses,
-            pageFrame: pageFrame
-        )
-        
         // Start the appropriate gaze source
         if eyeTrackingService.isSupported && !useFallbackMode {
             progressTracker.trackingMethod = .eyeTracking
             eyeTrackingService.startTracking()
+            progressTracker.startTracking(
+                pageNumber: pageNumber,
+                verses: verses,
+                pageFrame: pageFrame
+            )
         } else if useFallbackMode {
             // User has explicitly requested heuristic (fallback) mode
             progressTracker.trackingMethod = .heuristic
             fallbackEstimator.arabicWordsPerMinute = readingSpeed
+            progressTracker.startTracking(
+                pageNumber: pageNumber,
+                verses: verses,
+                pageFrame: pageFrame
+            )
             fallbackEstimator.startForPage(pageFrame: pageFrame)
             trackingState = .tracking(GazePoint(screenPosition: .zero, confidence: 0.5))
         } else {

--- a/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
@@ -52,13 +52,15 @@ public final class EyeTrackingCoordinator: ObservableObject {
     ///
     /// Passing `context` when disabling ensures any buffered sessions are
     /// flushed to SwiftData before the coordinator clears its state.
+    ///
+    /// When enabling, this method **only** sets `isEnabled = true`.
+    /// The actual service start (including gaze-binding setup and
+    /// `progressTracker` configuration) is deferred to the next call to
+    /// `activate(pageNumber:verses:pageFrame:onPageCompleted:)`, which
+    /// guarantees that all subsystems are ready before gaze samples arrive.
     public func setEnabled(_ enabled: Bool, context: ModelContext? = nil) {
         isEnabled = enabled
-        if enabled {
-            if eyeTrackingService.isSupported && !useFallbackMode {
-                eyeTrackingService.startTracking()
-            }
-        } else {
+        if !enabled {
             deactivate(context: context)
         }
     }

--- a/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
@@ -12,6 +12,7 @@
 import Foundation
 import SwiftUI
 import Combine
+import SwiftData
 
 /// Coordinates all eye-tracking subsystems and provides a single
 /// integration point for `MushafView`.
@@ -176,11 +177,16 @@ public final class EyeTrackingCoordinator: ObservableObject {
         if eyeTrackingService.isSupported && !useFallbackMode {
             progressTracker.trackingMethod = .eyeTracking
             eyeTrackingService.startTracking()
-        } else if useFallbackMode || !eyeTrackingService.isSupported {
+        } else if useFallbackMode {
+            // User has explicitly requested heuristic (fallback) mode
             progressTracker.trackingMethod = .heuristic
             fallbackEstimator.arabicWordsPerMinute = readingSpeed
             fallbackEstimator.startForPage(pageFrame: pageFrame)
             trackingState = .tracking(GazePoint(screenPosition: .zero, confidence: 0.5))
+        } else {
+            // TrueDepth unsupported and fallback mode is off — do not start heuristic tracking
+            progressTracker.trackingMethod = .eyeTracking
+            trackingState = .unavailable(reason: String(localized: "TrueDepth camera is required but not available on this device."))
         }
         
         AppLogger.shared.info("Eye tracking coordinator activated for page \(pageNumber)", category: .ui)

--- a/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
@@ -27,11 +27,11 @@ import SwiftData
 @MainActor
 public final class EyeTrackingCoordinator: ObservableObject {
     
-    // MARK: - Sub-services (public for settings binding)
+    // MARK: - Sub-services (internal for implementation)
     
-    public let eyeTrackingService = EyeTrackingService()
-    public let fallbackEstimator = FallbackGazeEstimator()
-    public let progressTracker = ReadingProgressTracker()
+    internal let eyeTrackingService = EyeTrackingService()
+    internal let fallbackEstimator = FallbackGazeEstimator()
+    internal let progressTracker = ReadingProgressTracker()
     
     // MARK: - Published State
     

--- a/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
@@ -1,0 +1,176 @@
+//
+//  EyeTrackingCoordinator.swift
+//  MushafImad
+//
+//  Ties together the EyeTrackingService, FallbackGazeEstimator,
+//  GazeToVerseMapper, and ReadingProgressTracker into a single
+//  coordinator that MushafView can consume.
+//
+//  Created for Ramadan Impact — exploratory research (Issue #22).
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+/// Coordinates all eye-tracking subsystems and provides a single
+/// integration point for `MushafView`.
+///
+/// Usage:
+/// ```swift
+/// @StateObject private var eyeCoordinator = EyeTrackingCoordinator()
+/// // In your view body:
+/// .onAppear { eyeCoordinator.activate(pageNumber: 1, verses: [...], pageFrame: ...) }
+/// .onDisappear { eyeCoordinator.deactivate() }
+/// ```
+@MainActor
+public final class EyeTrackingCoordinator: ObservableObject {
+    
+    // MARK: - Sub-services (public for settings binding)
+    
+    public let eyeTrackingService = EyeTrackingService()
+    public let fallbackEstimator = FallbackGazeEstimator()
+    public let progressTracker = ReadingProgressTracker()
+    
+    // MARK: - Published State
+    
+    /// The verse currently being read (auto-highlighted).
+    @Published public var gazeHighlightedVerse: Verse?
+    
+    /// Current gaze point for overlay rendering.
+    @Published public var currentGaze: GazePoint?
+    
+    /// Overall tracking state.
+    @Published public var trackingState: EyeTrackingState = .inactive
+    
+    /// Whether the feature is enabled by the user.
+    @AppStorage("eye_tracking_enabled") public var isEnabled: Bool = false
+    @AppStorage("eye_tracking_auto_highlight") private var autoHighlight: Bool = true
+    @AppStorage("eye_tracking_auto_advance") private var autoAdvance: Bool = false
+    @AppStorage("eye_tracking_show_overlay") public var showOverlay: Bool = false
+    @AppStorage("eye_tracking_show_debug") public var showDebugInfo: Bool = false
+    @AppStorage("eye_tracking_dwell_time") private var dwellTime: Double = 1.5
+    @AppStorage("eye_tracking_reading_speed") private var readingSpeed: Double = 80
+    @AppStorage("eye_tracking_use_fallback") private var useFallbackMode: Bool = false
+    
+    // MARK: - Private
+    
+    private var cancellables = Set<AnyCancellable>()
+    private var gazeUpdateTimer: Timer?
+    
+    // MARK: - Init
+    
+    public init() {
+        setupBindings()
+    }
+    
+    // MARK: - Bindings
+    
+    private func setupBindings() {
+        // Forward active verse changes
+        progressTracker.onActiveVerseChanged = { [weak self] verse in
+            guard let self else { return }
+            if self.autoHighlight {
+                self.gazeHighlightedVerse = verse
+            }
+        }
+        
+        // Observe eye tracking service state
+        eyeTrackingService.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.trackingState = state
+            }
+            .store(in: &cancellables)
+        
+        // Forward gaze from eye tracking service
+        eyeTrackingService.$currentGaze
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .sink { [weak self] gaze in
+                guard let self else { return }
+                self.currentGaze = gaze
+                self.progressTracker.processGazePoint(gaze)
+            }
+            .store(in: &cancellables)
+        
+        // Forward gaze from fallback estimator
+        fallbackEstimator.$estimatedGaze
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .sink { [weak self] gaze in
+                guard let self else { return }
+                // Only use fallback when eye tracking is not active
+                guard !self.eyeTrackingService.isSupported || self.useFallbackMode else { return }
+                self.currentGaze = gaze
+                self.progressTracker.processGazePoint(gaze)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Lifecycle
+    
+    /// Activate tracking for a specific page.
+    ///
+    /// - Parameters:
+    ///   - pageNumber: The Mushaf page number (1–604).
+    ///   - verses: The verses on the current page.
+    ///   - pageFrame: The on-screen frame of the page content area.
+    ///   - onPageCompleted: Callback when the tracker detects page completion.
+    public func activate(
+        pageNumber: Int,
+        verses: [Verse],
+        pageFrame: CGRect,
+        onPageCompleted: (() -> Void)? = nil
+    ) {
+        guard isEnabled else { return }
+        
+        // Configure the progress tracker
+        progressTracker.dwellTimeThreshold = dwellTime
+        progressTracker.autoAdvanceEnabled = autoAdvance
+        progressTracker.onPageCompleted = onPageCompleted
+        
+        // Start tracking
+        progressTracker.startTracking(
+            pageNumber: pageNumber,
+            verses: verses,
+            pageFrame: pageFrame
+        )
+        
+        // Start the appropriate gaze source
+        if eyeTrackingService.isSupported && !useFallbackMode {
+            eyeTrackingService.startTracking()
+        } else if useFallbackMode || !eyeTrackingService.isSupported {
+            fallbackEstimator.arabicWordsPerMinute = readingSpeed
+            fallbackEstimator.startForPage(pageFrame: pageFrame)
+            trackingState = .tracking(GazePoint(screenPosition: .zero, confidence: 0.5))
+        }
+        
+        AppLogger.shared.info("Eye tracking coordinator activated for page \(pageNumber)", category: .ui)
+    }
+    
+    /// Deactivate all tracking.
+    public func deactivate() {
+        eyeTrackingService.stopTracking()
+        fallbackEstimator.stopEstimating()
+        progressTracker.stopTracking()
+        gazeHighlightedVerse = nil
+        currentGaze = nil
+        trackingState = .inactive
+    }
+    
+    /// Update geometry after layout changes.
+    public func updateGeometry(frame: CGRect) {
+        progressTracker.updateGeometry(frame: frame)
+    }
+    
+    /// Pause tracking (app backgrounded, sheet presented, etc.).
+    public func pause() {
+        fallbackEstimator.pause()
+    }
+    
+    /// Resume tracking after a pause.
+    public func resume() {
+        fallbackEstimator.resume()
+    }
+}

--- a/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
@@ -45,8 +45,8 @@ public final class EyeTrackingCoordinator: ObservableObject {
     @Published public var trackingState: EyeTrackingState = .inactive
     
     /// Whether the feature is enabled by the user.
-    @AppStorage("eye_tracking_enabled") public var isEnabled: Bool = false
-    @AppStorage("eye_tracking_auto_highlight") private var autoHighlight: Bool = true
+    @AppStorage("mushaf_imad_eye_tracking_enabled") public var isEnabled: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_auto_highlight") private var autoHighlight: Bool = true
     
     /// Enable or disable eye-tracking.
     ///
@@ -64,12 +64,12 @@ public final class EyeTrackingCoordinator: ObservableObject {
             deactivate(context: context)
         }
     }
-    @AppStorage("eye_tracking_auto_advance") private var autoAdvance: Bool = false
-    @AppStorage("eye_tracking_show_overlay") public var showOverlay: Bool = false
-    @AppStorage("eye_tracking_show_debug") public var showDebugInfo: Bool = false
-    @AppStorage("eye_tracking_dwell_time") private var dwellTime: Double = 1.5
-    @AppStorage("eye_tracking_reading_speed") private var readingSpeed: Double = 80
-    @AppStorage("eye_tracking_use_fallback") private var useFallbackMode: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_auto_advance") private var autoAdvance: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_show_overlay") public var showOverlay: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_show_debug") public var showDebugInfo: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_dwell_time") private var dwellTime: Double = 1.5
+    @AppStorage("mushaf_imad_eye_tracking_reading_speed") private var readingSpeed: Double = 80
+    @AppStorage("mushaf_imad_eye_tracking_use_fallback") private var useFallbackMode: Bool = false
     
     // MARK: - Private
     

--- a/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingCoordinator.swift
@@ -46,6 +46,17 @@ public final class EyeTrackingCoordinator: ObservableObject {
     /// Whether the feature is enabled by the user.
     @AppStorage("eye_tracking_enabled") public var isEnabled: Bool = false
     @AppStorage("eye_tracking_auto_highlight") private var autoHighlight: Bool = true
+    
+    public func setEnabled(_ enabled: Bool) {
+        isEnabled = enabled
+        if enabled {
+            if eyeTrackingService.isSupported && !useFallbackMode {
+                eyeTrackingService.startTracking()
+            }
+        } else {
+            deactivate()
+        }
+    }
     @AppStorage("eye_tracking_auto_advance") private var autoAdvance: Bool = false
     @AppStorage("eye_tracking_show_overlay") public var showOverlay: Bool = false
     @AppStorage("eye_tracking_show_debug") public var showDebugInfo: Bool = false
@@ -56,6 +67,7 @@ public final class EyeTrackingCoordinator: ObservableObject {
     // MARK: - Private
     
     private var cancellables = Set<AnyCancellable>()
+    private var gazeCancellables = Set<AnyCancellable>()
     private var gazeUpdateTimer: Timer?
     
     // MARK: - Init
@@ -72,8 +84,23 @@ public final class EyeTrackingCoordinator: ObservableObject {
             guard let self else { return }
             if self.autoHighlight {
                 self.gazeHighlightedVerse = verse
+            } else {
+                DispatchQueue.main.async {
+                    self.gazeHighlightedVerse = nil
+                }
             }
         }
+        
+        NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                if !self.autoHighlight && self.gazeHighlightedVerse != nil {
+                    self.gazeHighlightedVerse = nil
+                }
+            }
+            .store(in: &cancellables)
+
         
         // Observe eye tracking service state
         eyeTrackingService.$state
@@ -83,6 +110,9 @@ public final class EyeTrackingCoordinator: ObservableObject {
             }
             .store(in: &cancellables)
         
+    }
+    
+    private func setupGazeBindings() {
         // Forward gaze from eye tracking service
         eyeTrackingService.$currentGaze
             .receive(on: DispatchQueue.main)
@@ -92,7 +122,7 @@ public final class EyeTrackingCoordinator: ObservableObject {
                 self.currentGaze = gaze
                 self.progressTracker.processGazePoint(gaze)
             }
-            .store(in: &cancellables)
+            .store(in: &gazeCancellables)
         
         // Forward gaze from fallback estimator
         fallbackEstimator.$estimatedGaze
@@ -105,7 +135,7 @@ public final class EyeTrackingCoordinator: ObservableObject {
                 self.currentGaze = gaze
                 self.progressTracker.processGazePoint(gaze)
             }
-            .store(in: &cancellables)
+            .store(in: &gazeCancellables)
     }
     
     // MARK: - Lifecycle
@@ -125,6 +155,11 @@ public final class EyeTrackingCoordinator: ObservableObject {
     ) {
         guard isEnabled else { return }
         
+        gazeCancellables.removeAll()
+        eyeTrackingService.stopTracking()
+        fallbackEstimator.stopEstimating()
+        setupGazeBindings()
+        
         // Configure the progress tracker
         progressTracker.dwellTimeThreshold = dwellTime
         progressTracker.autoAdvanceEnabled = autoAdvance
@@ -139,8 +174,10 @@ public final class EyeTrackingCoordinator: ObservableObject {
         
         // Start the appropriate gaze source
         if eyeTrackingService.isSupported && !useFallbackMode {
+            progressTracker.trackingMethod = .eyeTracking
             eyeTrackingService.startTracking()
         } else if useFallbackMode || !eyeTrackingService.isSupported {
+            progressTracker.trackingMethod = .heuristic
             fallbackEstimator.arabicWordsPerMinute = readingSpeed
             fallbackEstimator.startForPage(pageFrame: pageFrame)
             trackingState = .tracking(GazePoint(screenPosition: .zero, confidence: 0.5))
@@ -150,10 +187,13 @@ public final class EyeTrackingCoordinator: ObservableObject {
     }
     
     /// Deactivate all tracking.
-    public func deactivate() {
+    public func deactivate(context: ModelContext? = nil) {
         eyeTrackingService.stopTracking()
         fallbackEstimator.stopEstimating()
         progressTracker.stopTracking()
+        if let context = context {
+            progressTracker.persistSession(context: context)
+        }
         gazeHighlightedVerse = nil
         currentGaze = nil
         trackingState = .inactive
@@ -162,15 +202,22 @@ public final class EyeTrackingCoordinator: ObservableObject {
     /// Update geometry after layout changes.
     public func updateGeometry(frame: CGRect) {
         progressTracker.updateGeometry(frame: frame)
+        fallbackEstimator.updateGeometry(frame: frame)
     }
     
     /// Pause tracking (app backgrounded, sheet presented, etc.).
     public func pause() {
         fallbackEstimator.pause()
+        if eyeTrackingService.isSupported && !useFallbackMode {
+            eyeTrackingService.stopTracking()
+        }
     }
     
     /// Resume tracking after a pause.
     public func resume() {
         fallbackEstimator.resume()
+        if eyeTrackingService.isSupported && !useFallbackMode {
+            eyeTrackingService.startTracking()
+        }
     }
 }

--- a/Sources/MushafImad/EyeTracking/EyeTrackingOverlayView.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingOverlayView.swift
@@ -105,6 +105,11 @@ public struct EyeTrackingOverlayView: View {
                     pulseScale = 1.4
                 }
             }
+            .onDisappear {
+                withAnimation {
+                    pulseScale = 1.0
+                }
+            }
     }
     
     // MARK: - Progress Bar
@@ -240,7 +245,7 @@ public struct EyeTrackingOverlayView: View {
                             .font(.system(size: 10, design: .monospaced))
                     }
                     
-                    Text("Line: \(tracker.activeLineIndex) / 14")
+                    Text("Line: \(tracker.activeLineIndex) / \(GazeToVerseMapper.linesPerPage - 1)")
                         .font(.system(size: 10, design: .monospaced))
                     
                     if let verse = tracker.activeVerse {

--- a/Sources/MushafImad/EyeTracking/EyeTrackingOverlayView.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingOverlayView.swift
@@ -1,0 +1,269 @@
+//
+//  EyeTrackingOverlayView.swift
+//  MushafImad
+//
+//  Debug / visualization overlay that shows the gaze point,
+//  active verse info, and reading progress bar.
+//
+//  Created for Ramadan Impact — exploratory research (Issue #22).
+//
+
+import SwiftUI
+
+/// A translucent overlay that visualizes eye-tracking data on top of the Mushaf page.
+///
+/// **Features:**
+/// - Animated gaze dot that follows the estimated gaze position
+/// - Active verse indicator showing chapter:verse
+/// - Reading progress bar along the side
+/// - Debug info panel (togglable)
+///
+/// This view is intended for development / research and can be toggled
+/// via `EyeTrackingSettingsView`.
+public struct EyeTrackingOverlayView: View {
+    @ObservedObject var tracker: ReadingProgressTracker
+    var currentGaze: GazePoint?
+    var showDebugInfo: Bool
+    var trackingState: EyeTrackingState
+    
+    @State private var gazeAnimationPosition: CGPoint = .zero
+    @State private var pulseScale: CGFloat = 1.0
+    
+    public init(
+        tracker: ReadingProgressTracker,
+        currentGaze: GazePoint? = nil,
+        showDebugInfo: Bool = false,
+        trackingState: EyeTrackingState = .inactive
+    ) {
+        self.tracker = tracker
+        self.currentGaze = currentGaze
+        self.showDebugInfo = showDebugInfo
+        self.trackingState = trackingState
+    }
+    
+    public var body: some View {
+        ZStack {
+            // Gaze dot
+            if let gaze = currentGaze {
+                gazeDot(at: gaze)
+            }
+            
+            // Reading progress bar (right side for RTL)
+            progressBar
+            
+            // Active verse indicator
+            if let verse = tracker.activeVerse {
+                activeVerseIndicator(verse: verse)
+            }
+            
+            // Status indicator
+            statusBadge
+            
+            // Debug panel
+            if showDebugInfo {
+                debugPanel
+            }
+        }
+        .allowsHitTesting(false) // Passthrough all touches
+        .onChange(of: currentGaze?.screenPosition) { _, newPos in
+            if let pos = newPos {
+                withAnimation(.interpolatingSpring(stiffness: 80, damping: 12)) {
+                    gazeAnimationPosition = pos
+                }
+            }
+        }
+    }
+    
+    // MARK: - Gaze Dot
+    
+    @ViewBuilder
+    private func gazeDot(at gaze: GazePoint) -> some View {
+        let size: CGFloat = 24
+        let confidence = CGFloat(gaze.confidence)
+        
+        Circle()
+            .fill(
+                RadialGradient(
+                    colors: [
+                        Color.green.opacity(0.8 * confidence),
+                        Color.green.opacity(0.2 * confidence)
+                    ],
+                    center: .center,
+                    startRadius: 2,
+                    endRadius: size / 2
+                )
+            )
+            .frame(width: size, height: size)
+            .overlay(
+                Circle()
+                    .stroke(Color.green.opacity(0.6 * confidence), lineWidth: 2)
+                    .scaleEffect(pulseScale)
+            )
+            .position(gazeAnimationPosition)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                    pulseScale = 1.4
+                }
+            }
+    }
+    
+    // MARK: - Progress Bar
+    
+    private var progressBar: some View {
+        GeometryReader { geometry in
+            VStack {
+                Spacer()
+                    .frame(height: geometry.size.height * 0.1)
+                
+                // Vertical progress bar on the leading edge (right side in RTL)
+                ZStack(alignment: .top) {
+                    // Track
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.gray.opacity(0.2))
+                        .frame(width: 6, height: geometry.size.height * 0.8)
+                    
+                    // Fill
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(
+                            LinearGradient(
+                                colors: [Color.green, Color.blue],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .frame(
+                            width: 6,
+                            height: geometry.size.height * 0.8 * tracker.readingProgress
+                        )
+                        .animation(.easeInOut(duration: 0.3), value: tracker.readingProgress)
+                }
+                
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, 4)
+        }
+    }
+    
+    // MARK: - Active Verse Indicator
+    
+    @ViewBuilder
+    private func activeVerseIndicator(verse: Verse) -> some View {
+        VStack {
+            Spacer()
+            
+            HStack(spacing: 8) {
+                Image(systemName: "eye.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.green)
+                
+                Text("\(verse.chapterNumber):\(verse.number)")
+                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.primary)
+                
+                Spacer()
+                
+                Text("\(Int(tracker.readingProgress * 100))%")
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(.ultraThinMaterial, in: Capsule())
+            .padding(.horizontal, 16)
+            .padding(.bottom, 8)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+        .animation(.spring(response: 0.3), value: verse.verseID)
+    }
+    
+    // MARK: - Status Badge
+    
+    private var statusBadge: some View {
+        VStack {
+            HStack {
+                Spacer()
+                
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(statusColor)
+                        .frame(width: 8, height: 8)
+                    
+                    Text(statusText)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.ultraThinMaterial, in: Capsule())
+            }
+            .padding(.trailing, 12)
+            .padding(.top, 8)
+            
+            Spacer()
+        }
+    }
+    
+    private var statusColor: Color {
+        switch trackingState {
+        case .tracking: return .green
+        case .initializing: return .yellow
+        case .faceLost: return .orange
+        case .inactive: return .gray
+        case .unavailable: return .red
+        }
+    }
+    
+    private var statusText: String {
+        switch trackingState {
+        case .tracking: return String(localized: "Tracking")
+        case .initializing: return String(localized: "Starting…")
+        case .faceLost: return String(localized: "Face lost")
+        case .inactive: return String(localized: "Inactive")
+        case .unavailable: return String(localized: "Unavailable")
+        }
+    }
+    
+    // MARK: - Debug Panel
+    
+    private var debugPanel: some View {
+        VStack {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("👁️ Eye Tracking Debug")
+                        .font(.system(size: 11, weight: .bold))
+                    
+                    if let gaze = currentGaze {
+                        Text("Position: (\(Int(gaze.screenPosition.x)), \(Int(gaze.screenPosition.y)))")
+                            .font(.system(size: 10, design: .monospaced))
+                        Text("Confidence: \(String(format: "%.2f", gaze.confidence))")
+                            .font(.system(size: 10, design: .monospaced))
+                    }
+                    
+                    Text("Line: \(tracker.activeLineIndex) / 14")
+                        .font(.system(size: 10, design: .monospaced))
+                    
+                    if let verse = tracker.activeVerse {
+                        Text("Verse: \(verse.chapterNumber):\(verse.number)")
+                            .font(.system(size: 10, design: .monospaced))
+                    }
+                    
+                    Text("Progress: \(String(format: "%.0f", tracker.readingProgress * 100))%")
+                        .font(.system(size: 10, design: .monospaced))
+                    
+                    Text("Page done: \(tracker.pageCompleted ? "✅" : "❌")")
+                        .font(.system(size: 10, design: .monospaced))
+                }
+                .foregroundStyle(.primary)
+                .padding(8)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                
+                Spacer()
+            }
+            .padding(.leading, 12)
+            .padding(.top, 60)
+            
+            Spacer()
+        }
+    }
+}

--- a/Sources/MushafImad/EyeTracking/EyeTrackingOverlayView.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingOverlayView.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///
 /// This view is intended for development / research and can be toggled
 /// via `EyeTrackingSettingsView`.
-internal struct EyeTrackingOverlayView: View {
+public struct EyeTrackingOverlayView: View {
     @ObservedObject var tracker: ReadingProgressTracker
     var currentGaze: GazePoint?
     var showDebugInfo: Bool
@@ -29,7 +29,7 @@ internal struct EyeTrackingOverlayView: View {
     @State private var gazeAnimationPosition: CGPoint = .zero
     @State private var pulseScale: CGFloat = 1.0
     
-    internal init(
+    public init(
         tracker: ReadingProgressTracker,
         currentGaze: GazePoint? = nil,
         showDebugInfo: Bool = false,

--- a/Sources/MushafImad/EyeTracking/EyeTrackingOverlayView.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingOverlayView.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///
 /// This view is intended for development / research and can be toggled
 /// via `EyeTrackingSettingsView`.
-public struct EyeTrackingOverlayView: View {
+internal struct EyeTrackingOverlayView: View {
     @ObservedObject var tracker: ReadingProgressTracker
     var currentGaze: GazePoint?
     var showDebugInfo: Bool
@@ -29,7 +29,7 @@ public struct EyeTrackingOverlayView: View {
     @State private var gazeAnimationPosition: CGPoint = .zero
     @State private var pulseScale: CGFloat = 1.0
     
-    public init(
+    internal init(
         tracker: ReadingProgressTracker,
         currentGaze: GazePoint? = nil,
         showDebugInfo: Bool = false,

--- a/Sources/MushafImad/EyeTracking/EyeTrackingService.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingService.swift
@@ -66,7 +66,7 @@ public enum EyeTrackingState: Sendable, Equatable {
 /// - Note: Requires iPhone X or later (TrueDepth camera).
 ///   Falls back to `.unavailable` on unsupported devices.
 @MainActor
-public final class EyeTrackingService: NSObject, ObservableObject {
+internal final class EyeTrackingService: NSObject, ObservableObject {
     
     // MARK: - Published State
     

--- a/Sources/MushafImad/EyeTracking/EyeTrackingService.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingService.swift
@@ -1,0 +1,308 @@
+//
+//  EyeTrackingService.swift
+//  MushafImad
+//
+//  Eye-tracking gaze estimation using ARKit's TrueDepth camera.
+//  This is an experimental feature (Issue #22) — opt-in, privacy-first.
+//
+//  Created for Ramadan Impact — exploratory research.
+//
+
+import Foundation
+import Combine
+import SwiftUI
+
+#if canImport(ARKit) && canImport(UIKit)
+import ARKit
+import UIKit
+#endif
+
+// MARK: - Gaze Point
+
+/// A single gaze sample in screen coordinates with a confidence score.
+public struct GazePoint: Sendable, Equatable {
+    /// The estimated gaze position in screen-space coordinates (points).
+    public let screenPosition: CGPoint
+    
+    /// Confidence of the gaze estimate (0.0 – 1.0).
+    /// Higher values indicate more reliable tracking.
+    public let confidence: Float
+    
+    /// Timestamp of the sample.
+    public let timestamp: TimeInterval
+    
+    public init(screenPosition: CGPoint, confidence: Float, timestamp: TimeInterval = CACurrentMediaTime()) {
+        self.screenPosition = screenPosition
+        self.confidence = min(1.0, max(0.0, confidence))
+        self.timestamp = timestamp
+    }
+}
+
+// MARK: - Tracking State
+
+/// The operational state of the eye tracking system.
+public enum EyeTrackingState: Sendable, Equatable {
+    /// Not started or explicitly stopped.
+    case inactive
+    
+    /// Initializing ARKit session.
+    case initializing
+    
+    /// Actively tracking — the associated `GazePoint` is the latest sample.
+    case tracking(GazePoint)
+    
+    /// The user's face / eyes are temporarily not visible.
+    case faceLost
+    
+    /// Eye tracking is not available on this device.
+    case unavailable(reason: String)
+}
+
+// MARK: - Eye Tracking Service
+
+/// Manages ARKit-based eye tracking to estimate the user's gaze position
+/// on screen. All data stays local and the service is opt-in only.
+///
+/// - Note: Requires iPhone X or later (TrueDepth camera).
+///   Falls back to `.unavailable` on unsupported devices.
+@MainActor
+public final class EyeTrackingService: NSObject, ObservableObject {
+    
+    // MARK: - Published State
+    
+    /// Current tracking state, observed by the UI.
+    @Published public private(set) var state: EyeTrackingState = .inactive
+    
+    /// The most recent smoothed gaze point (nil when not tracking).
+    @Published public private(set) var currentGaze: GazePoint?
+    
+    /// Whether ARKit face tracking is supported on this device.
+    @Published public private(set) var isSupported: Bool = false
+    
+    // MARK: - Configuration
+    
+    /// Minimum confidence threshold — gaze samples below this are discarded.
+    public var minimumConfidence: Float = 0.3
+    
+    /// Smoothing factor for the Kalman-style filter (0 = no smoothing, 1 = full lag).
+    /// A value around 0.7 works well for reading.
+    public var smoothingFactor: CGFloat = 0.7
+    
+    // MARK: - Private
+    
+#if canImport(ARKit) && canImport(UIKit) && !targetEnvironment(simulator)
+    private var arSession: ARSession?
+    private var isRunning = false
+#endif
+    
+    /// Smoothed position accumulator.
+    private var smoothedPosition: CGPoint = .zero
+    private var hasInitialSample = false
+    
+    // MARK: - Lifecycle
+    
+    public override init() {
+        super.init()
+        checkAvailability()
+    }
+    
+    // MARK: - Availability Check
+    
+    private func checkAvailability() {
+#if canImport(ARKit) && canImport(UIKit) && !targetEnvironment(simulator)
+        isSupported = ARFaceTrackingConfiguration.isSupported
+#else
+        isSupported = false
+#endif
+    }
+    
+    // MARK: - Start / Stop
+    
+    /// Begin eye tracking. Requires camera permission.
+    public func startTracking() {
+        guard state == .inactive || state == .faceLost else { return }
+        
+#if canImport(ARKit) && canImport(UIKit) && !targetEnvironment(simulator)
+        guard ARFaceTrackingConfiguration.isSupported else {
+            state = .unavailable(reason: String(localized: "This device does not support face tracking (TrueDepth camera required)."))
+            AppLogger.shared.warn("Eye tracking unavailable: no TrueDepth camera", category: .ui)
+            return
+        }
+        
+        state = .initializing
+        
+        let configuration = ARFaceTrackingConfiguration()
+        configuration.isLightEstimationEnabled = false  // Don't need it — saves battery
+        
+        let session = ARSession()
+        session.delegate = self
+        session.run(configuration, options: [.resetTracking, .removeExistingAnchors])
+        
+        arSession = session
+        isRunning = true
+        
+        AppLogger.shared.info("Eye tracking started", category: .ui)
+#else
+        state = .unavailable(reason: String(localized: "Eye tracking requires iOS with TrueDepth camera."))
+        AppLogger.shared.info("Eye tracking not available on this platform", category: .ui)
+#endif
+    }
+    
+    /// Stop eye tracking and release the AR session.
+    public func stopTracking() {
+#if canImport(ARKit) && canImport(UIKit) && !targetEnvironment(simulator)
+        arSession?.pause()
+        arSession = nil
+        isRunning = false
+#endif
+        state = .inactive
+        currentGaze = nil
+        hasInitialSample = false
+        AppLogger.shared.info("Eye tracking stopped", category: .ui)
+    }
+    
+    // MARK: - Gaze Projection
+    
+    /// Projects a 3D look-at vector from the face anchor to a 2D screen point.
+    ///
+    /// The `lookAtPoint` from `ARFaceAnchor` gives us a direction vector
+    /// in face-anchor space. We transform it to world space, then project
+    /// onto the screen plane.
+#if canImport(ARKit) && canImport(UIKit) && !targetEnvironment(simulator)
+    private func projectGazeToScreen(faceAnchor: ARFaceAnchor, frame: ARFrame) -> GazePoint? {
+        guard let screenSize = screenSize else { return nil }
+        
+        // The lookAtPoint is in face anchor coordinate space
+        let lookAt = faceAnchor.lookAtPoint
+        
+        // Eye positions in face anchor space
+        let leftEye = faceAnchor.leftEyeTransform
+        let rightEye = faceAnchor.rightEyeTransform
+        
+        // Average eye position (midpoint between eyes)
+        let eyeMidX = (leftEye.columns.3.x + rightEye.columns.3.x) / 2.0
+        let eyeMidY = (leftEye.columns.3.y + rightEye.columns.3.y) / 2.0
+        let eyeMidZ = (leftEye.columns.3.z + rightEye.columns.3.z) / 2.0
+        
+        // Gaze direction from the midpoint of the eyes
+        let gazeDirectionX = lookAt.x - eyeMidX
+        let gazeDirectionY = lookAt.y - eyeMidY
+        let gazeDirectionZ = lookAt.z - eyeMidZ
+        
+        // Map gaze direction to screen coordinates
+        // The face is typically ~30–50cm from the phone screen
+        // lookAtPoint X ranges roughly from -0.05 to 0.05 for typical reading
+        // lookAtPoint Y ranges roughly from -0.05 to 0.05
+        
+        // Normalize to screen space (inverted X because front camera is mirrored)
+        let normalizedX = CGFloat(0.5 - gazeDirectionX * 8.0)
+        let normalizedY = CGFloat(0.5 - gazeDirectionY * 8.0)
+        
+        // Clamp to screen bounds
+        let screenX = min(screenSize.width, max(0, normalizedX * screenSize.width))
+        let screenY = min(screenSize.height, max(0, normalizedY * screenSize.height))
+        
+        // Confidence based on how centered the gaze is and tracking quality
+        let distFromCenter = sqrt(pow(gazeDirectionX, 2) + pow(gazeDirectionY, 2))
+        let rawConfidence = max(0, 1.0 - distFromCenter * 5.0)
+        let trackingConfidence = faceAnchor.isTracked ? rawConfidence : rawConfidence * 0.3
+        
+        return GazePoint(
+            screenPosition: CGPoint(x: screenX, y: screenY),
+            confidence: trackingConfidence
+        )
+    }
+    
+    private var screenSize: CGSize? {
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first else { return nil }
+        return windowScene.screen.bounds.size
+    }
+#endif
+    
+    // MARK: - Smoothing
+    
+    /// Apply exponential moving average to reduce jitter.
+    private func smoothGaze(_ raw: CGPoint) -> CGPoint {
+        if !hasInitialSample {
+            smoothedPosition = raw
+            hasInitialSample = true
+            return raw
+        }
+        
+        let alpha = smoothingFactor
+        smoothedPosition = CGPoint(
+            x: alpha * smoothedPosition.x + (1 - alpha) * raw.x,
+            y: alpha * smoothedPosition.y + (1 - alpha) * raw.y
+        )
+        return smoothedPosition
+    }
+}
+
+// MARK: - ARSessionDelegate
+
+#if canImport(ARKit) && canImport(UIKit) && !targetEnvironment(simulator)
+extension EyeTrackingService: ARSessionDelegate {
+    
+    nonisolated public func session(_ session: ARSession, didUpdate frame: ARFrame) {
+        // Process at ~15 FPS instead of 30 to save battery
+        // We skip every other frame
+        let frameTime = frame.timestamp
+        
+        Task { @MainActor in
+            guard let faceAnchor = frame.anchors.compactMap({ $0 as? ARFaceAnchor }).first else {
+                if self.state != .faceLost && self.state != .inactive {
+                    self.state = .faceLost
+                }
+                return
+            }
+            
+            guard faceAnchor.isTracked else {
+                self.state = .faceLost
+                return
+            }
+            
+            guard let rawGaze = self.projectGazeToScreen(faceAnchor: faceAnchor, frame: frame) else {
+                return
+            }
+            
+            // Filter low-confidence samples
+            guard rawGaze.confidence >= self.minimumConfidence else {
+                return
+            }
+            
+            // Smooth the gaze position
+            let smoothedPos = self.smoothGaze(rawGaze.screenPosition)
+            let smoothedGaze = GazePoint(
+                screenPosition: smoothedPos,
+                confidence: rawGaze.confidence,
+                timestamp: frameTime
+            )
+            
+            self.currentGaze = smoothedGaze
+            self.state = .tracking(smoothedGaze)
+        }
+    }
+    
+    nonisolated public func session(_ session: ARSession, didFailWithError error: Error) {
+        Task { @MainActor in
+            self.state = .unavailable(reason: error.localizedDescription)
+            AppLogger.shared.error("AR session failed: \(error.localizedDescription)", category: .ui)
+        }
+    }
+    
+    nonisolated public func sessionWasInterrupted(_ session: ARSession) {
+        Task { @MainActor in
+            self.state = .faceLost
+        }
+    }
+    
+    nonisolated public func sessionInterruptionEnded(_ session: ARSession) {
+        Task { @MainActor in
+            // Session will resume automatically
+            AppLogger.shared.info("AR session interruption ended", category: .ui)
+        }
+    }
+}
+#endif

--- a/Sources/MushafImad/EyeTracking/EyeTrackingService.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingService.swift
@@ -83,14 +83,41 @@ internal final class EyeTrackingService: NSObject, ObservableObject {
     
     /// Multiplier used to scale the gaze direction vector from the face lookAtPoint 
     /// to screen bounds, effectively controlling the tracking sensitivity based on user distance.
-    public var gazeProjectionScale: Float = 8.0
+    /// Valid range: > 0
+    public var gazeProjectionScale: Float = 8.0 {
+        didSet {
+            guard gazeProjectionScale > 0 else {
+                gazeProjectionScale = oldValue
+                assertionFailure("gazeProjectionScale must be greater than 0")
+                return
+            }
+        }
+    }
     
     /// Minimum confidence threshold — gaze samples below this are discarded.
-    public var minimumConfidence: Float = 0.3
+    /// Valid range: 0.0...1.0
+    public var minimumConfidence: Float = 0.3 {
+        didSet {
+            guard (0.0...1.0).contains(minimumConfidence) else {
+                minimumConfidence = max(0.0, min(1.0, minimumConfidence))
+                assertionFailure("minimumConfidence must be between 0.0 and 1.0 (clamped to valid range)")
+                return
+            }
+        }
+    }
     
     /// Smoothing factor for the Kalman-style filter (0 = no smoothing, 1 = full lag).
     /// A value around 0.7 works well for reading.
-    public var smoothingFactor: CGFloat = 0.7
+    /// Valid range: 0.0...1.0
+    public var smoothingFactor: CGFloat = 0.7 {
+        didSet {
+            guard (0.0...1.0).contains(smoothingFactor) else {
+                smoothingFactor = max(0.0, min(1.0, smoothingFactor))
+                assertionFailure("smoothingFactor must be between 0.0 and 1.0 (clamped to valid range)")
+                return
+            }
+        }
+    }
     
     // MARK: - Private
     

--- a/Sources/MushafImad/EyeTracking/EyeTrackingService.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingService.swift
@@ -81,6 +81,10 @@ public final class EyeTrackingService: NSObject, ObservableObject {
     
     // MARK: - Configuration
     
+    /// Multiplier used to scale the gaze direction vector from the face lookAtPoint 
+    /// to screen bounds, effectively controlling the tracking sensitivity based on user distance.
+    public var gazeProjectionScale: Float = 8.0
+    
     /// Minimum confidence threshold — gaze samples below this are discarded.
     public var minimumConfidence: Float = 0.3
     
@@ -98,6 +102,7 @@ public final class EyeTrackingService: NSObject, ObservableObject {
     /// Smoothed position accumulator.
     private var smoothedPosition: CGPoint = .zero
     private var hasInitialSample = false
+    private var lastProcessedFrameTimestamp: TimeInterval?
     
     // MARK: - Lifecycle
     
@@ -195,8 +200,8 @@ public final class EyeTrackingService: NSObject, ObservableObject {
         // lookAtPoint Y ranges roughly from -0.05 to 0.05
         
         // Normalize to screen space (inverted X because front camera is mirrored)
-        let normalizedX = CGFloat(0.5 - gazeDirectionX * 8.0)
-        let normalizedY = CGFloat(0.5 - gazeDirectionY * 8.0)
+        let normalizedX = CGFloat(0.5 - gazeDirectionX * gazeProjectionScale)
+        let normalizedY = CGFloat(0.5 - gazeDirectionY * gazeProjectionScale)
         
         // Clamp to screen bounds
         let screenX = min(screenSize.width, max(0, normalizedX * screenSize.width))
@@ -251,6 +256,15 @@ extension EyeTrackingService: ARSessionDelegate {
         let frameTime = frame.timestamp
         
         Task { @MainActor in
+            let shouldProcess: Bool
+            if let lastTime = self.lastProcessedFrameTimestamp {
+                shouldProcess = (frameTime - lastTime) >= (1.0 / 15.0)
+            } else {
+                shouldProcess = true
+            }
+            guard shouldProcess else { return }
+            self.lastProcessedFrameTimestamp = frameTime
+            
             guard let faceAnchor = frame.anchors.compactMap({ $0 as? ARFaceAnchor }).first else {
                 if self.state != .faceLost && self.state != .inactive {
                     self.state = .faceLost

--- a/Sources/MushafImad/EyeTracking/EyeTrackingSettingsView.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingSettingsView.swift
@@ -29,11 +29,11 @@ public struct EyeTrackingSettingsView: View {
     
     // MARK: - Environment
     
-    @ObservedObject var eyeTrackingService: EyeTrackingService
+    @ObservedObject var coordinator: EyeTrackingCoordinator
     @Environment(\.dismiss) private var dismiss
     
-    public init(eyeTrackingService: EyeTrackingService) {
-        self.eyeTrackingService = eyeTrackingService
+    public init(coordinator: EyeTrackingCoordinator) {
+        self.coordinator = coordinator
     }
     
     public var body: some View {
@@ -69,11 +69,7 @@ public struct EyeTrackingSettingsView: View {
                         }
                     }
                     .onChange(of: isEnabled) { _, newValue in
-                        if newValue {
-                            eyeTrackingService.startTracking()
-                        } else {
-                            eyeTrackingService.stopTracking()
-                        }
+                        coordinator.setEnabled(newValue)
                     }
                     
                     // Device support status
@@ -82,15 +78,15 @@ public struct EyeTrackingSettingsView: View {
                             .foregroundStyle(.secondary)
                         Spacer()
                         HStack(spacing: 4) {
-                            Image(systemName: eyeTrackingService.isSupported ? "checkmark.circle.fill" : "xmark.circle.fill")
-                                .foregroundStyle(eyeTrackingService.isSupported ? .green : .red)
-                            Text(eyeTrackingService.isSupported ? String(localized: "Supported") : String(localized: "Not Available"))
+                            Image(systemName: coordinator.eyeTrackingService.isSupported ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                .foregroundStyle(coordinator.eyeTrackingService.isSupported ? .green : .red)
+                            Text(coordinator.eyeTrackingService.isSupported ? String(localized: "Supported") : String(localized: "Not Available"))
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         }
                     }
                     
-                    if !eyeTrackingService.isSupported {
+                    if !coordinator.eyeTrackingService.isSupported {
                         Toggle(isOn: $useFallbackMode) {
                             Label {
                                 VStack(alignment: .leading, spacing: 2) {
@@ -265,5 +261,5 @@ public struct EyeTrackingSettingsView: View {
 // MARK: - Preview
 
 #Preview {
-    EyeTrackingSettingsView(eyeTrackingService: EyeTrackingService())
+    EyeTrackingSettingsView(coordinator: EyeTrackingCoordinator())
 }

--- a/Sources/MushafImad/EyeTracking/EyeTrackingSettingsView.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingSettingsView.swift
@@ -1,0 +1,269 @@
+//
+//  EyeTrackingSettingsView.swift
+//  MushafImad
+//
+//  User-facing settings panel for enabling and configuring
+//  eye-tracking–assisted reading progress.
+//
+//  Created for Ramadan Impact — exploratory research (Issue #22).
+//
+
+import SwiftUI
+
+/// Settings view that lets the user opt in to eye-tracking features
+/// and configure reading parameters.
+///
+/// All settings are persisted via `@AppStorage` so they survive app restarts.
+public struct EyeTrackingSettingsView: View {
+    
+    // MARK: - Settings
+    
+    @AppStorage("eye_tracking_enabled") private var isEnabled: Bool = false
+    @AppStorage("eye_tracking_auto_highlight") private var autoHighlight: Bool = true
+    @AppStorage("eye_tracking_auto_advance") private var autoAdvance: Bool = false
+    @AppStorage("eye_tracking_show_overlay") private var showOverlay: Bool = false
+    @AppStorage("eye_tracking_show_debug") private var showDebugInfo: Bool = false
+    @AppStorage("eye_tracking_dwell_time") private var dwellTime: Double = 1.5
+    @AppStorage("eye_tracking_reading_speed") private var readingSpeed: Double = 80
+    @AppStorage("eye_tracking_use_fallback") private var useFallbackMode: Bool = false
+    
+    // MARK: - Environment
+    
+    @ObservedObject var eyeTrackingService: EyeTrackingService
+    @Environment(\.dismiss) private var dismiss
+    
+    public init(eyeTrackingService: EyeTrackingService) {
+        self.eyeTrackingService = eyeTrackingService
+    }
+    
+    public var body: some View {
+        NavigationStack {
+            Form {
+                // MARK: - Experimental Banner
+                Section {
+                    HStack(spacing: 12) {
+                        Image(systemName: "flask.fill")
+                            .font(.system(size: 28))
+                            .foregroundStyle(.purple)
+                            .symbolEffect(.pulse, isActive: isEnabled)
+                        
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Experimental Feature")
+                                .font(.headline)
+                            Text("Eye tracking is a research feature. Accuracy may vary by device and lighting conditions.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                
+                // MARK: - Enable Toggle
+                Section {
+                    Toggle(isOn: $isEnabled) {
+                        Label {
+                            Text("Enable Eye Tracking")
+                        } icon: {
+                            Image(systemName: "eye.fill")
+                                .foregroundStyle(.green)
+                        }
+                    }
+                    .onChange(of: isEnabled) { _, newValue in
+                        if newValue {
+                            eyeTrackingService.startTracking()
+                        } else {
+                            eyeTrackingService.stopTracking()
+                        }
+                    }
+                    
+                    // Device support status
+                    HStack {
+                        Text("Device Support")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        HStack(spacing: 4) {
+                            Image(systemName: eyeTrackingService.isSupported ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                .foregroundStyle(eyeTrackingService.isSupported ? .green : .red)
+                            Text(eyeTrackingService.isSupported ? String(localized: "Supported") : String(localized: "Not Available"))
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    
+                    if !eyeTrackingService.isSupported {
+                        Toggle(isOn: $useFallbackMode) {
+                            Label {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Use Reading Estimation")
+                                    Text("Estimates progress based on reading speed")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            } icon: {
+                                Image(systemName: "speedometer")
+                                    .foregroundStyle(.blue)
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Tracking")
+                } footer: {
+                    Text("Eye tracking requires an iPhone with TrueDepth camera (iPhone X or later). Your camera data stays entirely on-device and is never stored or transmitted.")
+                }
+                
+                // MARK: - Behavior
+                Section {
+                    Toggle(isOn: $autoHighlight) {
+                        Label {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Auto-Highlight Verse")
+                                Text("Highlights the verse you're reading")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } icon: {
+                            Image(systemName: "highlighter")
+                                .foregroundStyle(.yellow)
+                        }
+                    }
+                    
+                    Toggle(isOn: $autoAdvance) {
+                        Label {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Auto-Advance Page")
+                                Text("Automatically flip to next page when finished reading")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } icon: {
+                            Image(systemName: "arrow.right.doc.on.clipboard")
+                                .foregroundStyle(.blue)
+                        }
+                    }
+                } header: {
+                    Text("Behavior")
+                }
+                
+                // MARK: - Tuning
+                Section {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Dwell Time")
+                            Spacer()
+                            Text("\(String(format: "%.1f", dwellTime))s")
+                                .foregroundStyle(.secondary)
+                                .font(.subheadline.monospacedDigit())
+                        }
+                        
+                        Slider(value: $dwellTime, in: 0.5...5.0, step: 0.5)
+                            .tint(.green)
+                        
+                        Text("How long your gaze must rest on a verse before it's marked as read")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.vertical, 4)
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Reading Speed")
+                            Spacer()
+                            Text("\(Int(readingSpeed)) WPM")
+                                .foregroundStyle(.secondary)
+                                .font(.subheadline.monospacedDigit())
+                        }
+                        
+                        Slider(value: $readingSpeed, in: 30...200, step: 10)
+                            .tint(.blue)
+                        
+                        Text("Arabic words per minute (used for fallback estimation)")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.vertical, 4)
+                } header: {
+                    Text("Tuning")
+                }
+                
+                // MARK: - Developer
+                Section {
+                    Toggle(isOn: $showOverlay) {
+                        Label {
+                            Text("Show Tracking Overlay")
+                        } icon: {
+                            Image(systemName: "eye.trianglebadge.exclamationmark")
+                                .foregroundStyle(.orange)
+                        }
+                    }
+                    
+                    Toggle(isOn: $showDebugInfo) {
+                        Label {
+                            Text("Show Debug Info")
+                        } icon: {
+                            Image(systemName: "ladybug.fill")
+                                .foregroundStyle(.red)
+                        }
+                    }
+                } header: {
+                    Text("Developer")
+                } footer: {
+                    Text("These options are for testing and development. The overlay shows a dot where your gaze is estimated to be.")
+                }
+                
+                // MARK: - Privacy
+                Section {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label {
+                            Text("Privacy Commitment")
+                                .fontWeight(.semibold)
+                        } icon: {
+                            Image(systemName: "lock.shield.fill")
+                                .foregroundStyle(.green)
+                        }
+                        
+                        VStack(alignment: .leading, spacing: 6) {
+                            privacyItem(icon: "eye.slash", text: "Camera data is processed on-device only")
+                            privacyItem(icon: "icloud.slash", text: "No gaze data is uploaded or stored")
+                            privacyItem(icon: "hand.raised.fill", text: "Feature is entirely opt-in")
+                            privacyItem(icon: "trash", text: "Stop tracking to immediately release camera")
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .navigationTitle(String(localized: "Eye Tracking"))
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "Done")) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    @ViewBuilder
+    private func privacyItem(icon: String, text: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+            
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    EyeTrackingSettingsView(eyeTrackingService: EyeTrackingService())
+}

--- a/Sources/MushafImad/EyeTracking/EyeTrackingSettingsView.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingSettingsView.swift
@@ -18,14 +18,14 @@ public struct EyeTrackingSettingsView: View {
     
     // MARK: - Settings
     
-    @AppStorage("eye_tracking_enabled") private var isEnabled: Bool = false
-    @AppStorage("eye_tracking_auto_highlight") private var autoHighlight: Bool = true
-    @AppStorage("eye_tracking_auto_advance") private var autoAdvance: Bool = false
-    @AppStorage("eye_tracking_show_overlay") private var showOverlay: Bool = false
-    @AppStorage("eye_tracking_show_debug") private var showDebugInfo: Bool = false
-    @AppStorage("eye_tracking_dwell_time") private var dwellTime: Double = 1.5
-    @AppStorage("eye_tracking_reading_speed") private var readingSpeed: Double = 80
-    @AppStorage("eye_tracking_use_fallback") private var useFallbackMode: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_enabled") private var isEnabled: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_auto_highlight") private var autoHighlight: Bool = true
+    @AppStorage("mushaf_imad_eye_tracking_auto_advance") private var autoAdvance: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_show_overlay") private var showOverlay: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_show_debug") private var showDebugInfo: Bool = false
+    @AppStorage("mushaf_imad_eye_tracking_dwell_time") private var dwellTime: Double = 1.5
+    @AppStorage("mushaf_imad_eye_tracking_reading_speed") private var readingSpeed: Double = 80
+    @AppStorage("mushaf_imad_eye_tracking_use_fallback") private var useFallbackMode: Bool = false
     
     // MARK: - Environment
     

--- a/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
+++ b/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
@@ -36,13 +36,30 @@ internal final class FallbackGazeEstimator: ObservableObject {
     /// Average Arabic reading speed in words per minute.
     /// Quran reading tends to be slower due to tajweed rules.
     /// Typical range: 50–120 WPM for careful Arabic reading.
+    /// Valid range: > 0
     public var arabicWordsPerMinute: Double = 80 {
-        didSet { recalculateRate() }
+        didSet {
+            guard arabicWordsPerMinute > 0 else {
+                arabicWordsPerMinute = oldValue
+                assertionFailure("arabicWordsPerMinute must be greater than 0")
+                return
+            }
+            recalculateRate()
+        }
     }
     
     /// Approximate number of words per line in the Mushaf.
     /// Standard Hafs 1441 layout has roughly 8–12 words per line.
-    public var wordsPerLine: Double = 10
+    /// Valid range: > 0
+    public var wordsPerLine: Double = 10 {
+        didSet {
+            guard wordsPerLine > 0 else {
+                wordsPerLine = oldValue
+                assertionFailure("wordsPerLine must be greater than 0")
+                return
+            }
+        }
+    }
     
     /// Number of lines per page.
     public let linesPerPage: Int = 15

--- a/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
+++ b/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
@@ -79,8 +79,9 @@ public final class FallbackGazeEstimator: ObservableObject {
         
         // Update estimated position at ~4 Hz (enough for smooth progress)
         let timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+            guard let self else { return }
             Task { @MainActor in
-                self?.updateEstimatedGaze()
+                self.updateEstimatedGaze()
             }
         }
         RunLoop.main.add(timer, forMode: .common)

--- a/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
+++ b/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
@@ -21,7 +21,7 @@ import Combine
 /// 3. Account for pauses (app backgrounding, user interaction) by freezing the timer.
 /// 4. Publish estimated gaze points that the `ReadingProgressTracker` can consume.
 @MainActor
-public final class FallbackGazeEstimator: ObservableObject {
+internal final class FallbackGazeEstimator: ObservableObject {
     
     // MARK: - Published
     

--- a/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
+++ b/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
@@ -78,11 +78,13 @@ public final class FallbackGazeEstimator: ObservableObject {
         isActive = true
         
         // Update estimated position at ~4 Hz (enough for smooth progress)
-        updateTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.updateEstimatedGaze()
             }
         }
+        RunLoop.main.add(timer, forMode: .common)
+        updateTimer = timer
         
         AppLogger.shared.debug("Fallback gaze estimator started", category: .ui)
     }
@@ -116,6 +118,11 @@ public final class FallbackGazeEstimator: ObservableObject {
     public func resetPageTimer() {
         pageStartTime = Date()
         pausedDuration = 0
+    }
+    
+    /// Update geometry manually if it changes during active estimation
+    public func updateGeometry(frame: CGRect) {
+        currentPageFrame = frame
     }
     
     // MARK: - Internal

--- a/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
+++ b/Sources/MushafImad/EyeTracking/FallbackGazeEstimator.swift
@@ -1,0 +1,168 @@
+//
+//  FallbackGazeEstimator.swift
+//  MushafImad
+//
+//  Scroll-position and dwell-time based reading position estimator.
+//  Used when eye tracking is unavailable (macOS, older iPhones, simulators).
+//
+//  Created for Ramadan Impact — exploratory research (Issue #22).
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+/// Estimates the user's reading position using heuristic methods
+/// when hardware eye tracking is not available.
+///
+/// ## Strategy
+/// 1. When the user lands on a page, start a timer.
+/// 2. Estimate reading progress line-by-line based on configurable reading speed.
+/// 3. Account for pauses (app backgrounding, user interaction) by freezing the timer.
+/// 4. Publish estimated gaze points that the `ReadingProgressTracker` can consume.
+@MainActor
+public final class FallbackGazeEstimator: ObservableObject {
+    
+    // MARK: - Published
+    
+    /// The estimated gaze point from heuristics.
+    @Published public private(set) var estimatedGaze: GazePoint?
+    
+    /// Whether the estimator is actively running.
+    @Published public private(set) var isActive: Bool = false
+    
+    // MARK: - Configuration
+    
+    /// Average Arabic reading speed in words per minute.
+    /// Quran reading tends to be slower due to tajweed rules.
+    /// Typical range: 50–120 WPM for careful Arabic reading.
+    public var arabicWordsPerMinute: Double = 80 {
+        didSet { recalculateRate() }
+    }
+    
+    /// Approximate number of words per line in the Mushaf.
+    /// Standard Hafs 1441 layout has roughly 8–12 words per line.
+    public var wordsPerLine: Double = 10
+    
+    /// Number of lines per page.
+    public let linesPerPage: Int = 15
+    
+    // MARK: - Private
+    
+    private var pageStartTime: Date?
+    private var pausedDuration: TimeInterval = 0
+    private var pauseStart: Date?
+    private var updateTimer: Timer?
+    private var currentPageFrame: CGRect = .zero
+    
+    /// Seconds per line, derived from reading speed.
+    private var secondsPerLine: TimeInterval = 0
+    
+    // MARK: - Init
+    
+    public init() {
+        recalculateRate()
+    }
+    
+    // MARK: - Public API
+    
+    /// Start estimating reading progress for a new page.
+    ///
+    /// - Parameter pageFrame: The on-screen frame of the page content area.
+    public func startForPage(pageFrame: CGRect) {
+        stopEstimating()
+        
+        currentPageFrame = pageFrame
+        pageStartTime = Date()
+        pausedDuration = 0
+        isActive = true
+        
+        // Update estimated position at ~4 Hz (enough for smooth progress)
+        updateTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateEstimatedGaze()
+            }
+        }
+        
+        AppLogger.shared.debug("Fallback gaze estimator started", category: .ui)
+    }
+    
+    /// Stop the estimator (e.g., when navigating away from the page).
+    public func stopEstimating() {
+        updateTimer?.invalidate()
+        updateTimer = nil
+        isActive = false
+        estimatedGaze = nil
+        pageStartTime = nil
+        pausedDuration = 0
+        pauseStart = nil
+    }
+    
+    /// Pause estimation (e.g., when the app goes to background or a sheet is presented).
+    public func pause() {
+        guard pauseStart == nil else { return }
+        pauseStart = Date()
+    }
+    
+    /// Resume estimation after a pause.
+    public func resume() {
+        if let start = pauseStart {
+            pausedDuration += Date().timeIntervalSince(start)
+            pauseStart = nil
+        }
+    }
+    
+    /// Reset the timer for the current page (e.g., user scrolled back to top).
+    public func resetPageTimer() {
+        pageStartTime = Date()
+        pausedDuration = 0
+    }
+    
+    // MARK: - Internal
+    
+    private func recalculateRate() {
+        let wordsPerSecond = arabicWordsPerMinute / 60.0
+        secondsPerLine = wordsPerLine / wordsPerSecond
+    }
+    
+    private func updateEstimatedGaze() {
+        guard let startTime = pageStartTime, isActive else { return }
+        guard currentPageFrame.width > 0 else { return }
+        
+        // Calculate effective reading time (excluding pauses)
+        var elapsed = Date().timeIntervalSince(startTime) - pausedDuration
+        if let pauseStart {
+            elapsed -= Date().timeIntervalSince(pauseStart)
+        }
+        elapsed = max(0, elapsed)
+        
+        // Determine current estimated line
+        let estimatedLine = min(
+            linesPerPage - 1,
+            Int(elapsed / secondsPerLine)
+        )
+        
+        // Determine progress within the line (0.0 – 1.0)
+        let lineElapsed = elapsed - Double(estimatedLine) * secondsPerLine
+        let lineProgress = min(1.0, lineElapsed / secondsPerLine)
+        
+        // Convert to screen coordinates
+        // Reading direction is RTL, so X goes from right to left
+        let lineHeight = currentPageFrame.height / CGFloat(linesPerPage)
+        let headerOffset: CGFloat = 40  // Approximate header height
+        
+        let screenY = currentPageFrame.minY + headerOffset + (CGFloat(estimatedLine) + 0.5) * lineHeight
+        // RTL: start from right side and move left
+        let screenX = currentPageFrame.maxX - CGFloat(lineProgress) * currentPageFrame.width
+        
+        // Confidence decreases slightly over time (user might have paused reading)
+        let timeConfidence = max(0.3, 1.0 - Float(elapsed / (secondsPerLine * Double(linesPerPage) * 2.0)))
+        
+        let gaze = GazePoint(
+            screenPosition: CGPoint(x: screenX, y: screenY),
+            confidence: timeConfidence
+        )
+        
+        estimatedGaze = gaze
+    }
+}

--- a/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
+++ b/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
@@ -105,34 +105,46 @@ public final class GazeToVerseMapper: ObservableObject {
             return nil
         }
         
-        // Convert screen position to page-relative position
-        let relativeY = screenPos.y - pageFrame.minY - headerHeight
-        let relativeX = screenPos.x - pageFrame.minX
+        // Position relative to the page's top-left origin
+        let pageRelativeY = screenPos.y - pageFrame.minY
+        let pageRelativeX = screenPos.x - pageFrame.minX
         
-        // Determine which line the gaze falls on
+        // The vertical band occupied by the rendered lines:
+        //   top  = headerHeight (matches the PageHeaderView height passed by caller)
+        //   bottom = top + lineHeight * linesPerPage
         guard lineHeight > 0 else { return nil }
-        let lineIndex = Int(relativeY / lineHeight)
+        let lineBandTop: CGFloat = headerHeight
+        let lineBandBottom: CGFloat = lineBandTop + lineHeight * CGFloat(Self.linesPerPage)
         
-        // Clamp to valid line range
-        let clampedLine = min(Self.linesPerPage - 1, max(0, lineIndex))
+        // Return nil for header and footer regions — do NOT clamp into line 0 or 14
+        guard pageRelativeY >= lineBandTop && pageRelativeY <= lineBandBottom else {
+            return nil
+        }
+        
+        // Determine which line the gaze falls on relative to the band start
+        let relativeYInBand = pageRelativeY - lineBandTop
+        let lineIndex = Int(relativeYInBand / lineHeight)
+        
+        // Safety clamp (should always be in range given the guard above)
+        guard lineIndex >= 0 && lineIndex < Self.linesPerPage else {
+            return nil
+        }
         
         // Progress within the line (0 = top, 1 = bottom)
-        let lineProgress = (relativeY - CGFloat(clampedLine) * lineHeight) / lineHeight
+        let lineProgress = (relativeYInBand - CGFloat(lineIndex) * lineHeight) / lineHeight
         let clampedProgress = min(1.0, max(0.0, lineProgress))
         
-        // Find the verse at this position
-        // The page is RTL, so we need to account for that
-        let normalizedX = relativeX / pageFrame.width
+        // Find the verse at this position (page uses RTL layout)
+        let normalizedX = pageRelativeX / pageFrame.width
         
-        // Find the verse whose highlight region on this line contains the gaze X position
         let matchedVerse = findVerseAtPosition(
             normalizedX: Float(normalizedX),
-            lineIndex: clampedLine,
+            lineIndex: lineIndex,
             verses: verses
         )
         
         return MappedGazeResult(
-            lineIndex: clampedLine,
+            lineIndex: lineIndex,
             verse: matchedVerse,
             verseID: matchedVerse?.verseID,
             confidence: gazePoint.confidence,

--- a/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
+++ b/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
@@ -18,9 +18,6 @@ public struct MappedGazeResult: Equatable, Sendable {
     /// The line index (0–14) that the gaze falls on.
     public let lineIndex: Int
     
-    /// The verse that the gaze is closest to on this line (nil if no verse occupies this region).
-    public let verse: Verse?
-    
     /// The verse's identifier — useful for quick equality checks.
     public let verseID: Int?
     
@@ -145,7 +142,6 @@ public final class GazeToVerseMapper: ObservableObject {
         
         return MappedGazeResult(
             lineIndex: lineIndex,
-            verse: matchedVerse,
             verseID: matchedVerse?.verseID,
             confidence: gazePoint.confidence,
             lineProgress: clampedProgress

--- a/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
+++ b/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
@@ -1,0 +1,209 @@
+//
+//  GazeToVerseMapper.swift
+//  MushafImad
+//
+//  Maps screen-space gaze coordinates to Mushaf lines and verses
+//  using the page layout metadata (VerseHighlight bounds).
+//
+//  Created for Ramadan Impact — exploratory research (Issue #22).
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - Mapped Gaze Result
+
+/// The result of mapping a gaze point to a specific location in the Mushaf.
+public struct MappedGazeResult: Equatable, Sendable {
+    /// The line index (0–14) that the gaze falls on.
+    public let lineIndex: Int
+    
+    /// The verse that the gaze is closest to on this line (nil if no verse occupies this region).
+    public let verse: Verse?
+    
+    /// The verse's identifier — useful for quick equality checks.
+    public let verseID: Int?
+    
+    /// Confidence of the mapping (inherits from gaze + geometric proximity).
+    public let confidence: Float
+    
+    /// The normalized position within the line (0 = top of line, 1 = bottom).
+    public let lineProgress: CGFloat
+    
+    public static func == (lhs: MappedGazeResult, rhs: MappedGazeResult) -> Bool {
+        lhs.lineIndex == rhs.lineIndex && lhs.verseID == rhs.verseID
+    }
+}
+
+// MARK: - Gaze Mapper
+
+/// Maps screen-space gaze coordinates to Mushaf page elements (lines and verses).
+///
+/// The Mushaf page layout consists of:
+/// - 15 lines per page (indices 0–14)
+/// - Each line has a fixed aspect ratio (1440:232)
+/// - Verses have `VerseHighlight` objects with `left`, `right`, and `line` properties
+///   that define their bounding region on the page
+///
+/// This mapper uses the page's geometry to determine which line and verse
+/// the user is looking at.
+@MainActor
+public final class GazeToVerseMapper: ObservableObject {
+    
+    // MARK: - Configuration
+    
+    /// The total number of lines per Mushaf page.
+    public static let linesPerPage = 15
+    
+    /// Original line image dimensions.
+    private static let originalLineWidth: CGFloat = 1440
+    private static let originalLineHeight: CGFloat = 232
+    
+    // MARK: - Page Geometry Cache
+    
+    /// Cached geometry for the current page, set when the page view measures itself.
+    private var pageFrame: CGRect = .zero
+    private var headerHeight: CGFloat = 0
+    private var lineHeight: CGFloat = 0
+    
+    // MARK: - Public API
+    
+    /// Update the mapper with the current page's on-screen geometry.
+    ///
+    /// Call this whenever the page layout changes (rotation, page flip, etc.)
+    ///
+    /// - Parameters:
+    ///   - frame: The on-screen frame of the page content area (excluding chrome).
+    ///   - headerOffset: The height of the page header above the lines.
+    public func updatePageGeometry(frame: CGRect, headerOffset: CGFloat = 40) {
+        self.pageFrame = frame
+        self.headerHeight = headerOffset
+        
+        // Each line occupies an equal fraction of the remaining height
+        let availableWidth = frame.width
+        let calculatedLineHeight = availableWidth / Self.originalLineWidth * Self.originalLineHeight
+        self.lineHeight = calculatedLineHeight * 0.73  // Match the 0.73 factor from QuranPageView
+    }
+    
+    /// Map a screen-space gaze point to a line and verse on the current page.
+    ///
+    /// - Parameters:
+    ///   - gazePoint: The estimated gaze position in screen coordinates.
+    ///   - verses: The verses on the current page (from `Page.verses1441`).
+    /// - Returns: A `MappedGazeResult` if the gaze falls within the page area, nil otherwise.
+    public func mapGazeToVerse(
+        gazePoint: GazePoint,
+        verses: [Verse]
+    ) -> MappedGazeResult? {
+        let screenPos = gazePoint.screenPosition
+        
+        // Check if gaze is within the page frame
+        guard pageFrame.contains(screenPos) else {
+            return nil
+        }
+        
+        // Convert screen position to page-relative position
+        let relativeY = screenPos.y - pageFrame.minY - headerHeight
+        let relativeX = screenPos.x - pageFrame.minX
+        
+        // Determine which line the gaze falls on
+        guard lineHeight > 0 else { return nil }
+        let lineIndex = Int(relativeY / lineHeight)
+        
+        // Clamp to valid line range
+        let clampedLine = min(Self.linesPerPage - 1, max(0, lineIndex))
+        
+        // Progress within the line (0 = top, 1 = bottom)
+        let lineProgress = (relativeY - CGFloat(clampedLine) * lineHeight) / lineHeight
+        let clampedProgress = min(1.0, max(0.0, lineProgress))
+        
+        // Find the verse at this position
+        // The page is RTL, so we need to account for that
+        let normalizedX = relativeX / pageFrame.width
+        
+        // Find the verse whose highlight region on this line contains the gaze X position
+        let matchedVerse = findVerseAtPosition(
+            normalizedX: Float(normalizedX),
+            lineIndex: clampedLine,
+            verses: verses
+        )
+        
+        return MappedGazeResult(
+            lineIndex: clampedLine,
+            verse: matchedVerse,
+            verseID: matchedVerse?.verseID,
+            confidence: gazePoint.confidence,
+            lineProgress: clampedProgress
+        )
+    }
+    
+    /// Estimate the current line based on scroll offset (for fallback mode).
+    ///
+    /// When eye tracking is unavailable, this provides a rough estimate
+    /// based on time and reading speed.
+    ///
+    /// - Parameters:
+    ///   - elapsedSeconds: Time the user has been on this page.
+    ///   - wordsPerMinute: Estimated reading speed for Arabic text.
+    ///   - totalWordsOnPage: Approximate word count for the page.
+    /// - Returns: Estimated line index (0–14).
+    public func estimateLineFromReadingTime(
+        elapsedSeconds: TimeInterval,
+        wordsPerMinute: Double = 80,
+        totalWordsOnPage: Int = 150
+    ) -> Int {
+        let wordsPerSecond = wordsPerMinute / 60.0
+        let wordsRead = wordsPerSecond * elapsedSeconds
+        let fractionRead = wordsRead / Double(totalWordsOnPage)
+        let estimatedLine = Int(fractionRead * Double(Self.linesPerPage))
+        return min(Self.linesPerPage - 1, max(0, estimatedLine))
+    }
+    
+    // MARK: - Private Helpers
+    
+    /// Find the verse whose highlight region contains the given normalized X position
+    /// on the specified line.
+    private func findVerseAtPosition(
+        normalizedX: Float,
+        lineIndex: Int,
+        verses: [Verse]
+    ) -> Verse? {
+        // The highlight coordinates use RTL layout:
+        // `left` and `right` are normalized positions where right > left
+        // In RTL, the visual left corresponds to (1 - right) and visual right to (1 - left)
+        
+        var bestMatch: Verse?
+        var smallestDistance: Float = .greatestFiniteMagnitude
+        
+        for verse in verses {
+            let highlights = verse.highlights1441.filter { $0.line == lineIndex }
+            
+            for highlight in highlights {
+                // Convert to visual coordinates (RTL)
+                let visualLeft = 1.0 - highlight.right
+                let visualRight = 1.0 - highlight.left
+                
+                // Check if the gaze X falls within this highlight's bounds
+                if normalizedX >= visualLeft && normalizedX <= visualRight {
+                    // Direct hit
+                    return verse
+                }
+                
+                // Track closest verse in case no direct hit
+                let centerX = (visualLeft + visualRight) / 2.0
+                let distance = abs(normalizedX - centerX)
+                if distance < smallestDistance {
+                    smallestDistance = distance
+                    bestMatch = verse
+                }
+            }
+        }
+        
+        // If we're within a reasonable distance (< 10% of page width), return nearest
+        if smallestDistance < 0.1 {
+            return bestMatch
+        }
+        
+        return nil
+    }
+}

--- a/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
+++ b/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
@@ -45,7 +45,7 @@ public struct MappedGazeResult: Equatable, Sendable {
 /// This mapper uses the page's geometry to determine which line and verse
 /// the user is looking at.
 @MainActor
-public final class GazeToVerseMapper: ObservableObject {
+internal final class GazeToVerseMapper: ObservableObject {
     
     // MARK: - Configuration
     

--- a/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
+++ b/Sources/MushafImad/EyeTracking/GazeToVerseMapper.swift
@@ -59,6 +59,9 @@ public final class GazeToVerseMapper: ObservableObject {
     private static let originalLineWidth: CGFloat = 1440
     private static let originalLineHeight: CGFloat = 232
     
+    /// Multiplier to match QuranPageView's internal line height scaling.
+    private static let lineHeightScale: CGFloat = 0.73
+    
     // MARK: - Page Geometry Cache
     
     /// Cached geometry for the current page, set when the page view measures itself.
@@ -82,7 +85,7 @@ public final class GazeToVerseMapper: ObservableObject {
         // Each line occupies an equal fraction of the remaining height
         let availableWidth = frame.width
         let calculatedLineHeight = availableWidth / Self.originalLineWidth * Self.originalLineHeight
-        self.lineHeight = calculatedLineHeight * 0.73  // Match the 0.73 factor from QuranPageView
+        self.lineHeight = calculatedLineHeight * Self.lineHeightScale  // Match the 0.73 factor from QuranPageView
     }
     
     /// Map a screen-space gaze point to a line and verse on the current page.

--- a/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
+++ b/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
@@ -83,6 +83,9 @@ public final class ReadingProgressTracker: ObservableObject {
     private var currentDwellVerse: Verse?
     private var dwellStartTime: Date?
     
+    /// The verse most recently mapped from a gaze point (even if dwell threshold not met).
+    private var lastMappedVerse: Verse?
+    
     /// For page completion detection
     private var lastLineDwellStart: Date?
     
@@ -95,9 +98,6 @@ public final class ReadingProgressTracker: ObservableObject {
     /// Current page context
     private var currentPageNumber: Int = 0
     private var currentPageVerses: [Verse] = []
-    
-    /// Sessions that are waiting to be persisted (e.g. from previous page turns).
-    private var pendingSessions: [ReadingSession] = []
     
     /// Cancellable subscriptions
     private var cancellables = Set<AnyCancellable>()
@@ -135,6 +135,7 @@ public final class ReadingProgressTracker: ObservableObject {
         sessionVerseID = nil
         confidenceAccumulator = 0
         confidenceSampleCount = 0
+        lastMappedVerse = nil
         
         isTracking = true
         
@@ -188,6 +189,11 @@ public final class ReadingProgressTracker: ObservableObject {
         // Dwell detection
         processDwellDetection(result: result)
         
+        // Update last mapped verse immediately (even if dwell not confirmed)
+        if let verseID = result.verseID {
+            lastMappedVerse = currentPageVerses.first(where: { $0.verseID == verseID })
+        }
+        
         // Page completion detection
         processPageCompletion(lineIndex: result.lineIndex)
     }
@@ -200,8 +206,12 @@ public final class ReadingProgressTracker: ObservableObject {
     // MARK: - Dwell Detection
     
     private func processDwellDetection(result: MappedGazeResult) {
-        guard let verse = result.verse else {
-            // Gaze is on a line but not on any verse — could be a header or gap
+        let verse = currentPageVerses.first(where: { $0.verseID == result.verseID })
+        
+        guard let verse = verse else {
+            // Gaze is on a line but not on any verse — reset dwell timer
+            currentDwellVerse = nil
+            dwellStartTime = nil
             return
         }
         
@@ -262,7 +272,7 @@ public final class ReadingProgressTracker: ObservableObject {
     private func finalizeSession() -> ReadingSession? {
         guard let startTime = sessionStartTime else { return nil }
         
-        let verse = activeVerse
+        let verse = activeVerse ?? lastMappedVerse
         let avgConfidence: Float
         if confidenceSampleCount > 0 {
             avgConfidence = confidenceAccumulator / Float(confidenceSampleCount)

--- a/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
+++ b/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
@@ -56,10 +56,28 @@ internal final class ReadingProgressTracker: ObservableObject {
     // MARK: - Configuration
     
     /// Minimum dwell time in seconds before a verse is considered "being read".
-    public var dwellTimeThreshold: TimeInterval = 1.5
+    /// Valid range: > 0
+    public var dwellTimeThreshold: TimeInterval = 1.5 {
+        didSet {
+            guard dwellTimeThreshold > 0 else {
+                dwellTimeThreshold = oldValue
+                assertionFailure("dwellTimeThreshold must be greater than 0")
+                return
+            }
+        }
+    }
     
     /// Time in seconds the user must dwell on the last line to trigger auto-advance.
-    public var pageCompletionDwellTime: TimeInterval = 3.0
+    /// Valid range: > 0
+    public var pageCompletionDwellTime: TimeInterval = 3.0 {
+        didSet {
+            guard pageCompletionDwellTime > 0 else {
+                pageCompletionDwellTime = oldValue
+                assertionFailure("pageCompletionDwellTime must be greater than 0")
+                return
+            }
+        }
+    }
     
     /// Whether to automatically advance to the next page when page is completed.
     public var autoAdvanceEnabled: Bool = true

--- a/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
+++ b/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
@@ -71,6 +71,9 @@ public final class ReadingProgressTracker: ObservableObject {
     
     // MARK: - Private State
     
+    /// Tracking method used for current session
+    public var trackingMethod: TrackingMethod = .eyeTracking
+    
     /// Currently tracked verse and the time the gaze first landed on it.
     private var currentDwellVerse: Verse?
     private var dwellStartTime: Date?
@@ -265,7 +268,7 @@ public final class ReadingProgressTracker: ObservableObject {
             startedAt: startTime,
             lastUpdatedAt: Date(),
             activeReadingDuration: Date().timeIntervalSince(startTime),
-            trackingMethod: .eyeTracking,
+            trackingMethod: trackingMethod,
             completedPage: pageCompleted,
             averageConfidence: avgConfidence
         )

--- a/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
+++ b/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
@@ -1,0 +1,323 @@
+//
+//  ReadingProgressTracker.swift
+//  MushafImad
+//
+//  Orchestrates eye-tracking data into meaningful reading progress:
+//  - Dwell time detection per verse
+//  - Auto-highlight of the active verse
+//  - Auto-advance to next page
+//  - Persistence of reading sessions
+//
+//  Created for Ramadan Impact — exploratory research (Issue #22).
+//
+
+import Foundation
+import SwiftUI
+import Combine
+import SwiftData
+
+/// Orchestrates gaze data from `EyeTrackingService` or `FallbackGazeEstimator`
+/// into actionable reading progress events.
+///
+/// ## Responsibilities
+/// 1. Consume gaze points and map them to verses via `GazeToVerseMapper`
+/// 2. Detect when the user has "read" a verse (dwell time exceeded)
+/// 3. Track the currently active verse for auto-highlighting
+/// 4. Detect page completion and trigger auto-advance
+/// 5. Persist reading sessions via SwiftData
+@MainActor
+public final class ReadingProgressTracker: ObservableObject {
+    
+    // MARK: - Published State
+    
+    /// The verse the user is currently reading (based on dwell detection).
+    @Published public private(set) var activeVerse: Verse?
+    
+    /// The line the gaze is currently on (0–14).
+    @Published public private(set) var activeLineIndex: Int = 0
+    
+    /// Whether the user appears to have finished reading the current page.
+    @Published public private(set) var pageCompleted: Bool = false
+    
+    /// Reading progress as a fraction (0.0 – 1.0) based on the active line.
+    @Published public private(set) var readingProgress: Double = 0
+    
+    /// Whether the tracker is actively monitoring.
+    @Published public private(set) var isTracking: Bool = false
+    
+    /// Last reading session result (for persistence).
+    @Published public private(set) var currentSession: ReadingSession?
+    
+    // MARK: - Configuration
+    
+    /// Minimum dwell time in seconds before a verse is considered "being read".
+    public var dwellTimeThreshold: TimeInterval = 1.5
+    
+    /// Time in seconds the user must dwell on the last line to trigger auto-advance.
+    public var pageCompletionDwellTime: TimeInterval = 3.0
+    
+    /// Whether to automatically advance to the next page when page is completed.
+    public var autoAdvanceEnabled: Bool = true
+    
+    /// Callback invoked when the tracker determines the user has finished the page.
+    public var onPageCompleted: (() -> Void)?
+    
+    /// Callback invoked when the active verse changes (for highlighting).
+    public var onActiveVerseChanged: ((Verse?) -> Void)?
+    
+    // MARK: - Dependencies
+    
+    private let gazeMapper = GazeToVerseMapper()
+    
+    // MARK: - Private State
+    
+    /// Currently tracked verse and the time the gaze first landed on it.
+    private var currentDwellVerse: Verse?
+    private var dwellStartTime: Date?
+    
+    /// For page completion detection
+    private var lastLineDwellStart: Date?
+    
+    /// Running session data
+    private var sessionStartTime: Date?
+    private var sessionVerseID: Int?
+    private var confidenceAccumulator: Float = 0
+    private var confidenceSampleCount: Int = 0
+    
+    /// Current page context
+    private var currentPageNumber: Int = 0
+    private var currentPageVerses: [Verse] = []
+    
+    /// Cancellable subscriptions
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - Public API
+    
+    /// Begin tracking reading progress for a specific page.
+    ///
+    /// - Parameters:
+    ///   - pageNumber: The Mushaf page number (1–604).
+    ///   - verses: The verses on this page.
+    ///   - pageFrame: The on-screen frame of the page content area.
+    public func startTracking(
+        pageNumber: Int,
+        verses: [Verse],
+        pageFrame: CGRect
+    ) {
+        stopTracking()
+        
+        currentPageNumber = pageNumber
+        currentPageVerses = verses
+        pageCompleted = false
+        readingProgress = 0
+        activeVerse = nil
+        activeLineIndex = 0
+        
+        gazeMapper.updatePageGeometry(frame: pageFrame)
+        
+        // Initialize session
+        sessionStartTime = Date()
+        sessionVerseID = nil
+        confidenceAccumulator = 0
+        confidenceSampleCount = 0
+        
+        isTracking = true
+        
+        AppLogger.shared.info("Reading progress tracker started for page \(pageNumber)", category: .ui)
+    }
+    
+    /// Stop tracking and persist the session.
+    public func stopTracking() {
+        guard isTracking else { return }
+        isTracking = false
+        
+        // Create final session for persistence
+        finalizeSession()
+        
+        // Reset state
+        currentDwellVerse = nil
+        dwellStartTime = nil
+        lastLineDwellStart = nil
+        currentPageVerses = []
+        
+        AppLogger.shared.info("Reading progress tracker stopped", category: .ui)
+    }
+    
+    /// Process a new gaze point from either the eye tracking service
+    /// or the fallback estimator.
+    ///
+    /// This is the main entry point — call it each time a new gaze sample arrives.
+    ///
+    /// - Parameter gazePoint: The latest gaze estimate.
+    public func processGazePoint(_ gazePoint: GazePoint) {
+        guard isTracking else { return }
+        
+        // Map gaze to a verse
+        guard let result = gazeMapper.mapGazeToVerse(
+            gazePoint: gazePoint,
+            verses: currentPageVerses
+        ) else {
+            return
+        }
+        
+        // Update active line
+        activeLineIndex = result.lineIndex
+        readingProgress = Double(result.lineIndex) / Double(GazeToVerseMapper.linesPerPage - 1)
+        
+        // Accumulate confidence
+        confidenceAccumulator += gazePoint.confidence
+        confidenceSampleCount += 1
+        
+        // Dwell detection
+        processDwellDetection(result: result)
+        
+        // Page completion detection
+        processPageCompletion(lineIndex: result.lineIndex)
+    }
+    
+    /// Update the page geometry (e.g., after rotation).
+    public func updateGeometry(frame: CGRect) {
+        gazeMapper.updatePageGeometry(frame: frame)
+    }
+    
+    // MARK: - Dwell Detection
+    
+    private func processDwellDetection(result: MappedGazeResult) {
+        guard let verse = result.verse else {
+            // Gaze is on a line but not on any verse — could be a header or gap
+            return
+        }
+        
+        if currentDwellVerse?.verseID == verse.verseID {
+            // Still dwelling on the same verse — check if threshold met
+            if let start = dwellStartTime,
+               Date().timeIntervalSince(start) >= dwellTimeThreshold {
+                // Verse is considered "being read"
+                if activeVerse?.verseID != verse.verseID {
+                    activeVerse = verse
+                    sessionVerseID = verse.verseID
+                    onActiveVerseChanged?(verse)
+                    
+                    AppLogger.shared.trace(
+                        "Active verse: \(verse.chapterNumber):\(verse.number) (dwell: \(String(format: "%.1f", Date().timeIntervalSince(start)))s)",
+                        category: .ui
+                    )
+                }
+            }
+        } else {
+            // Gaze moved to a different verse — reset dwell timer
+            currentDwellVerse = verse
+            dwellStartTime = Date()
+        }
+    }
+    
+    // MARK: - Page Completion
+    
+    private func processPageCompletion(lineIndex: Int) {
+        guard !pageCompleted else { return }
+        
+        let isLastLine = lineIndex >= GazeToVerseMapper.linesPerPage - 2  // last 2 lines
+        
+        if isLastLine {
+            if lastLineDwellStart == nil {
+                lastLineDwellStart = Date()
+            } else if let start = lastLineDwellStart,
+                      Date().timeIntervalSince(start) >= pageCompletionDwellTime {
+                // User has been reading the last lines long enough
+                pageCompleted = true
+                readingProgress = 1.0
+                
+                AppLogger.shared.info("Page \(currentPageNumber) completed via eye tracking", category: .ui)
+                
+                if autoAdvanceEnabled {
+                    onPageCompleted?()
+                }
+            }
+        } else {
+            // Not on last line — reset
+            lastLineDwellStart = nil
+        }
+    }
+    
+    // MARK: - Session Persistence
+    
+    private func finalizeSession() {
+        guard let startTime = sessionStartTime else { return }
+        
+        let verse = activeVerse
+        let avgConfidence: Float
+        if confidenceSampleCount > 0 {
+            avgConfidence = confidenceAccumulator / Float(confidenceSampleCount)
+        } else {
+            avgConfidence = 0
+        }
+        
+        let session = ReadingSession(
+            pageNumber: currentPageNumber,
+            lastVerseID: verse?.verseID ?? 0,
+            chapterNumber: verse?.chapterNumber ?? 0,
+            verseNumber: verse?.number ?? 0,
+            lastLineIndex: activeLineIndex,
+            startedAt: startTime,
+            lastUpdatedAt: Date(),
+            activeReadingDuration: Date().timeIntervalSince(startTime),
+            trackingMethod: .eyeTracking,
+            completedPage: pageCompleted,
+            averageConfidence: avgConfidence
+        )
+        
+        currentSession = session
+        
+        AppLogger.shared.info(
+            "Reading session finalized — page \(currentPageNumber), verse \(verse?.chapterNumber ?? 0):\(verse?.number ?? 0), duration \(String(format: "%.1f", Date().timeIntervalSince(startTime)))s",
+            category: .ui
+        )
+    }
+    
+    /// Persist the current session to SwiftData.
+    ///
+    /// - Parameter context: The SwiftData model context to save into.
+    public func persistSession(context: ModelContext) {
+        guard let session = currentSession else { return }
+        context.insert(session)
+        
+        do {
+            try context.save()
+            AppLogger.shared.info("Reading session persisted to SwiftData", category: .ui)
+        } catch {
+            AppLogger.shared.error("Failed to persist reading session: \(error.localizedDescription)", category: .ui)
+        }
+    }
+    
+    /// Retrieve the most recent reading session for a specific page.
+    ///
+    /// - Parameters:
+    ///   - pageNumber: The page to look up.
+    ///   - context: SwiftData model context.
+    /// - Returns: The most recent `ReadingSession` for that page, if any.
+    public func lastSession(
+        forPage pageNumber: Int,
+        context: ModelContext
+    ) -> ReadingSession? {
+        let descriptor = FetchDescriptor<ReadingSession>(
+            predicate: #Predicate { $0.pageNumber == pageNumber },
+            sortBy: [SortDescriptor(\.lastUpdatedAt, order: .reverse)]
+        )
+        return try? context.fetch(descriptor).first
+    }
+    
+    /// Retrieve the user's most recent reading position across all pages.
+    ///
+    /// - Parameter context: SwiftData model context.
+    /// - Returns: The most recent `ReadingSession` overall, if any.
+    public func lastReadingPosition(context: ModelContext) -> ReadingSession? {
+        let descriptor = FetchDescriptor<ReadingSession>(
+            sortBy: [SortDescriptor(\.lastUpdatedAt, order: .reverse)]
+        )
+        return try? context.fetch(descriptor).first
+    }
+}

--- a/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
+++ b/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
@@ -48,6 +48,11 @@ public final class ReadingProgressTracker: ObservableObject {
     /// Last reading session result (for persistence).
     @Published public private(set) var currentSession: ReadingSession?
     
+    /// Sessions finalized during page transitions but not yet written to SwiftData.
+    /// Accumulating into a buffer prevents a session from being overwritten when
+    /// ``startTracking`` calls ``stopTracking`` before ``persistSession(context:)`` runs.
+    private var pendingSessions: [ReadingSession] = []
+    
     // MARK: - Configuration
     
     /// Minimum dwell time in seconds before a verse is considered "being read".
@@ -90,6 +95,9 @@ public final class ReadingProgressTracker: ObservableObject {
     /// Current page context
     private var currentPageNumber: Int = 0
     private var currentPageVerses: [Verse] = []
+    
+    /// Sessions that are waiting to be persisted (e.g. from previous page turns).
+    private var pendingSessions: [ReadingSession] = []
     
     /// Cancellable subscriptions
     private var cancellables = Set<AnyCancellable>()
@@ -138,8 +146,10 @@ public final class ReadingProgressTracker: ObservableObject {
         guard isTracking else { return }
         isTracking = false
         
-        // Create final session for persistence
-        finalizeSession()
+        // Create final session for persistence and add to pending queue
+        if let session = finalizeSession() {
+            pendingSessions.append(session)
+        }
         
         // Reset state
         currentDwellVerse = nil
@@ -248,8 +258,9 @@ public final class ReadingProgressTracker: ObservableObject {
     
     // MARK: - Session Persistence
     
-    private func finalizeSession() {
-        guard let startTime = sessionStartTime else { return }
+    @discardableResult
+    private func finalizeSession() -> ReadingSession? {
+        guard let startTime = sessionStartTime else { return nil }
         
         let verse = activeVerse
         let avgConfidence: Float
@@ -279,20 +290,29 @@ public final class ReadingProgressTracker: ObservableObject {
             "Reading session finalized — page \(currentPageNumber), verse \(verse?.chapterNumber ?? 0):\(verse?.number ?? 0), duration \(String(format: "%.1f", Date().timeIntervalSince(startTime)))s",
             category: .ui
         )
+        
+        return session
     }
     
     /// Persist the current session to SwiftData.
     ///
     /// - Parameter context: The SwiftData model context to save into.
     public func persistSession(context: ModelContext) {
-        guard let session = currentSession else { return }
-        context.insert(session)
+        guard !pendingSessions.isEmpty else {
+            AppLogger.shared.debug("No pending reading sessions to persist", category: .ui)
+            return
+        }
+        
+        for session in pendingSessions {
+            context.insert(session)
+        }
         
         do {
             try context.save()
-            AppLogger.shared.info("Reading session persisted to SwiftData", category: .ui)
+            AppLogger.shared.info("Persisted \(pendingSessions.count) reading session(s) to SwiftData", category: .ui)
+            pendingSessions.removeAll()
         } catch {
-            AppLogger.shared.error("Failed to persist reading session: \(error.localizedDescription)", category: .ui)
+            AppLogger.shared.error("Failed to persist reading sessions: \(error.localizedDescription)", category: .ui)
         }
     }
     

--- a/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
+++ b/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
@@ -95,6 +95,11 @@ public final class ReadingProgressTracker: ObservableObject {
     private var confidenceAccumulator: Float = 0
     private var confidenceSampleCount: Int = 0
     
+    /// Pause tracking: total wall-clock time spent in paused state during this session.
+    private var accumulatedPausedDuration: TimeInterval = 0
+    /// When the current pause started (nil if not currently paused).
+    private var pauseStartTime: Date?
+    
     /// Current page context
     private var currentPageNumber: Int = 0
     private var currentPageVerses: [Verse] = []
@@ -136,6 +141,8 @@ public final class ReadingProgressTracker: ObservableObject {
         confidenceAccumulator = 0
         confidenceSampleCount = 0
         lastMappedVerse = nil
+        accumulatedPausedDuration = 0
+        pauseStartTime = nil
         
         isTracking = true
         
@@ -150,6 +157,12 @@ public final class ReadingProgressTracker: ObservableObject {
         // Create final session for persistence and add to pending queue
         if let session = finalizeSession() {
             pendingSessions.append(session)
+        }
+        
+        // If we were paused, close out the current pause interval
+        if let pauseStart = pauseStartTime {
+            accumulatedPausedDuration += Date().timeIntervalSince(pauseStart)
+            pauseStartTime = nil
         }
         
         // Reset state
@@ -175,6 +188,12 @@ public final class ReadingProgressTracker: ObservableObject {
             gazePoint: gazePoint,
             verses: currentPageVerses
         ) else {
+            // Gaze is outside the page content area — clear stale dwell state so an
+            // out-of-bounds sample cannot silently extend or complete a dwell on the
+            // next valid sample.
+            currentDwellVerse = nil
+            dwellStartTime = nil
+            lastLineDwellStart = nil
             return
         }
         
@@ -280,6 +299,12 @@ public final class ReadingProgressTracker: ObservableObject {
             avgConfidence = 0
         }
         
+        // Compute active (non-paused) duration. If we are currently paused, include
+        // the ongoing pause interval in the total paused time so it is excluded.
+        let now = Date()
+        let totalPaused = accumulatedPausedDuration + (pauseStartTime.map { now.timeIntervalSince($0) } ?? 0)
+        let activeDuration = max(0, now.timeIntervalSince(startTime) - totalPaused)
+        
         let session = ReadingSession(
             pageNumber: currentPageNumber,
             lastVerseID: verse?.verseID ?? 0,
@@ -287,8 +312,8 @@ public final class ReadingProgressTracker: ObservableObject {
             verseNumber: verse?.number ?? 0,
             lastLineIndex: activeLineIndex,
             startedAt: startTime,
-            lastUpdatedAt: Date(),
-            activeReadingDuration: Date().timeIntervalSince(startTime),
+            lastUpdatedAt: now,
+            activeReadingDuration: activeDuration,
             trackingMethod: trackingMethod,
             completedPage: pageCompleted,
             averageConfidence: avgConfidence
@@ -297,11 +322,29 @@ public final class ReadingProgressTracker: ObservableObject {
         currentSession = session
         
         AppLogger.shared.info(
-            "Reading session finalized — page \(currentPageNumber), verse \(verse?.chapterNumber ?? 0):\(verse?.number ?? 0), duration \(String(format: "%.1f", Date().timeIntervalSince(startTime)))s",
+            "Reading session finalized — page \(currentPageNumber), verse \(verse?.chapterNumber ?? 0):\(verse?.number ?? 0), active duration \(String(format: "%.1f", activeDuration))s (paused \(String(format: "%.1f", totalPaused))s)",
             category: .ui
         )
         
         return session
+    }
+    
+    // MARK: - Pause / Resume
+    
+    /// Record the start of a pause interval. Call when tracking is interrupted
+    /// (e.g. app backgrounded, settings sheet presented, face lost).
+    public func pauseTracking() {
+        guard isTracking, pauseStartTime == nil else { return }
+        pauseStartTime = Date()
+        AppLogger.shared.debug("Reading progress tracker paused", category: .ui)
+    }
+    
+    /// Close the current pause interval and resume accumulating active time.
+    public func resumeTracking() {
+        guard isTracking, let pauseStart = pauseStartTime else { return }
+        accumulatedPausedDuration += Date().timeIntervalSince(pauseStart)
+        pauseStartTime = nil
+        AppLogger.shared.debug("Reading progress tracker resumed (total paused so far: \(String(format: "%.1f", accumulatedPausedDuration))s)", category: .ui)
     }
     
     /// Persist the current session to SwiftData.

--- a/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
+++ b/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
@@ -26,7 +26,7 @@ import SwiftData
 /// 4. Detect page completion and trigger auto-advance
 /// 5. Persist reading sessions via SwiftData
 @MainActor
-public final class ReadingProgressTracker: ObservableObject {
+internal final class ReadingProgressTracker: ObservableObject {
     
     // MARK: - Published State
     

--- a/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
+++ b/Sources/MushafImad/EyeTracking/ReadingProgressTracker.swift
@@ -26,7 +26,7 @@ import SwiftData
 /// 4. Detect page completion and trigger auto-advance
 /// 5. Persist reading sessions via SwiftData
 @MainActor
-internal final class ReadingProgressTracker: ObservableObject {
+public final class ReadingProgressTracker: ObservableObject {
     
     // MARK: - Published State
     

--- a/Sources/MushafImad/MushafView.swift
+++ b/Sources/MushafImad/MushafView.swift
@@ -176,6 +176,8 @@ public struct MushafView: View {
             if newMode == .text {
                 let page = viewModel.scrollPosition ?? initialPage ?? 1
                 textModeInitialChapter = RealmService.shared.getChapterForPage(page)?.number ?? 1
+                eyeTrackingCoordinator.deactivate(context: modelContext)
+                pageContentFrame = .zero
             }
         }
         .toolbar {
@@ -451,8 +453,12 @@ public struct MushafView: View {
                     }
                     .onChange(of: eyeTrackingCoordinator.isEnabled) { _, enabled in
                         // Re-activate when the user enables tracking while this page is visible
-                        if enabled && viewModel.scrollPosition == pageNumber {
-                            activateTracking(for: pageNumber, frame: geo.frame(in: .global))
+                        if enabled {
+                            if viewModel.scrollPosition == pageNumber {
+                                activateTracking(for: pageNumber, frame: geo.frame(in: .global))
+                            }
+                        } else {
+                            eyeTrackingCoordinator.deactivate(context: modelContext)
                         }
                     }
                     .onChange(of: viewModel.scrollPosition) { _, newPage in

--- a/Sources/MushafImad/MushafView.swift
+++ b/Sources/MushafImad/MushafView.swift
@@ -233,6 +233,13 @@ public struct MushafView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+        .onChange(of: showEyeTrackingSettings) { _, isShowing in
+            if isShowing {
+                eyeTrackingCoordinator.pause()
+            } else if eyeTrackingCoordinator.isEnabled {
+                eyeTrackingCoordinator.resume()
+            }
+        }
     }
     // MARK: - Verse Action Bar
 
@@ -437,28 +444,46 @@ public struct MushafView: View {
                     .onAppear {
                         let frame = geo.frame(in: .global)
                         pageContentFrame = frame
-                        if eyeTrackingCoordinator.isEnabled {
-                            let verses = RealmService.shared.getVersesForPage(pageNumber)
-                            eyeTrackingCoordinator.activate(
-                                pageNumber: pageNumber,
-                                verses: verses,
-                                pageFrame: frame,
-                                onPageCompleted: {
-                                    if pageNumber < 604 {
-                                        withAnimation {
-                                            viewModel.scrollPosition = pageNumber + 1
-                                        }
-                                    }
-                                }
-                            )
+                        // Only activate if this is the currently-visible page
+                        if eyeTrackingCoordinator.isEnabled && viewModel.scrollPosition == pageNumber {
+                            activateTracking(for: pageNumber, frame: frame)
+                        }
+                    }
+                    .onChange(of: eyeTrackingCoordinator.isEnabled) { _, enabled in
+                        // Re-activate when the user enables tracking while this page is visible
+                        if enabled && viewModel.scrollPosition == pageNumber {
+                            activateTracking(for: pageNumber, frame: geo.frame(in: .global))
+                        }
+                    }
+                    .onChange(of: viewModel.scrollPosition) { _, newPage in
+                        // Activate when this page becomes the active scroll position
+                        if eyeTrackingCoordinator.isEnabled && newPage == pageNumber {
+                            activateTracking(for: pageNumber, frame: geo.frame(in: .global))
                         }
                     }
                     .onChange(of: geo.frame(in: .global)) { _, newFrame in
                         pageContentFrame = newFrame
-                        if eyeTrackingCoordinator.isEnabled {
+                        // Only update geometry for the current page to avoid stale overrides
+                        if eyeTrackingCoordinator.isEnabled && viewModel.scrollPosition == pageNumber {
                             eyeTrackingCoordinator.updateGeometry(frame: newFrame)
                         }
                     }
+            }
+        )
+    }
+
+    private func activateTracking(for pageNumber: Int, frame: CGRect) {
+        let verses = RealmService.shared.getVersesForPage(pageNumber)
+        eyeTrackingCoordinator.activate(
+            pageNumber: pageNumber,
+            verses: verses,
+            pageFrame: frame,
+            onPageCompleted: {
+                if pageNumber < 604 {
+                    withAnimation {
+                        viewModel.scrollPosition = pageNumber + 1
+                    }
+                }
             }
         )
     }

--- a/Sources/MushafImad/MushafView.swift
+++ b/Sources/MushafImad/MushafView.swift
@@ -226,10 +226,10 @@ public struct MushafView: View {
 #if canImport(UIKit)
             tiltManager.deactivate()
 #endif
-            eyeTrackingCoordinator.deactivate()
+            eyeTrackingCoordinator.deactivate(context: modelContext)
         }
         .sheet(isPresented: $showEyeTrackingSettings) {
-            EyeTrackingSettingsView(eyeTrackingService: eyeTrackingCoordinator.eyeTrackingService)
+            EyeTrackingSettingsView(coordinator: eyeTrackingCoordinator)
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
@@ -429,6 +429,36 @@ public struct MushafView: View {
                 if let action = externalPageTapHandler {
                     action()
                 }
+            }
+        )
+        .background(
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear {
+                        let frame = geo.frame(in: .global)
+                        pageContentFrame = frame
+                        if eyeTrackingCoordinator.isEnabled {
+                            let verses = RealmService.shared.getVersesForPage(pageNumber)
+                            eyeTrackingCoordinator.activate(
+                                pageNumber: pageNumber,
+                                verses: verses,
+                                pageFrame: frame,
+                                onPageCompleted: {
+                                    if pageNumber < 604 {
+                                        withAnimation {
+                                            viewModel.scrollPosition = pageNumber + 1
+                                        }
+                                    }
+                                }
+                            )
+                        }
+                    }
+                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                        pageContentFrame = newFrame
+                        if eyeTrackingCoordinator.isEnabled {
+                            eyeTrackingCoordinator.updateGeometry(frame: newFrame)
+                        }
+                    }
             }
         )
     }

--- a/Sources/MushafImad/MushafView.swift
+++ b/Sources/MushafImad/MushafView.swift
@@ -75,11 +75,13 @@ public struct MushafView: View {
 
     @State private var viewModel = ViewModel()
     @StateObject private var playerViewModel = QuranPlayerViewModel()
+    @StateObject private var eyeTrackingCoordinator = EyeTrackingCoordinator()
     @EnvironmentObject private var reciterService: ReciterService
     @EnvironmentObject private var toastManager: ToastManager
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     @State private var playingVerse: Verse? = nil
+    @State private var pageContentFrame: CGRect = .zero
 #if canImport(UIKit)
     @StateObject private var tiltManager = TiltScrollManager()
 #endif
@@ -88,6 +90,7 @@ public struct MushafView: View {
     @AppStorage("display_mode") private var displayMode: DisplayMode = .text
     @AppStorage("text_font_size") private var textFontSize: Double = 24.0
     @State private var textModeInitialChapter: Int = 1
+    @State private var showEyeTrackingSettings: Bool = false
 
 
     public init(initialPage: Int? = nil,
@@ -122,6 +125,16 @@ public struct MushafView: View {
             } else {
                 pageView
                     .foregroundStyle(.naturalBlack)
+            }
+            
+            // Eye tracking overlay (experimental)
+            if eyeTrackingCoordinator.isEnabled && eyeTrackingCoordinator.showOverlay {
+                EyeTrackingOverlayView(
+                    tracker: eyeTrackingCoordinator.progressTracker,
+                    currentGaze: eyeTrackingCoordinator.currentGaze,
+                    showDebugInfo: eyeTrackingCoordinator.showDebugInfo,
+                    trackingState: eyeTrackingCoordinator.trackingState
+                )
             }
         }
         .environment(\.colorScheme, readingTheme == .night ? .dark : .light)
@@ -213,6 +226,12 @@ public struct MushafView: View {
 #if canImport(UIKit)
             tiltManager.deactivate()
 #endif
+            eyeTrackingCoordinator.deactivate()
+        }
+        .sheet(isPresented: $showEyeTrackingSettings) {
+            EyeTrackingSettingsView(eyeTrackingService: eyeTrackingCoordinator.eyeTrackingService)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
     }
     // MARK: - Verse Action Bar
@@ -279,6 +298,13 @@ public struct MushafView: View {
             displayMode = (displayMode == .image) ? .text : .image
         } label: {
             Image(systemName: displayMode == .image ? "text.justify.leading" : "book.pages")
+        }
+        // Eye tracking settings button (experimental)
+        Button {
+            showEyeTrackingSettings = true
+        } label: {
+            Image(systemName: "eye")
+                .symbolEffect(.pulse, isActive: eyeTrackingCoordinator.isEnabled)
         }
     }
 

--- a/Tests/MushafImadSPMTests/FallbackGazeEstimatorTests.swift
+++ b/Tests/MushafImadSPMTests/FallbackGazeEstimatorTests.swift
@@ -1,0 +1,438 @@
+import Foundation
+import Testing
+import CoreGraphics
+@testable import MushafImad
+
+/// Tests for FallbackGazeEstimator to ensure heuristic estimation logic,
+/// scroll position tracking, and confidence calculation work correctly.
+@Suite(.serialized)
+@MainActor
+struct FallbackGazeEstimatorTests {
+    
+    // MARK: - Initialization Tests
+    
+    @Test
+    func testInitialState() async {
+        // Arrange & Act
+        let estimator = FallbackGazeEstimator()
+        
+        // Assert
+        #expect(estimator.estimatedGaze == nil)
+        #expect(estimator.isActive == false)
+        #expect(estimator.arabicWordsPerMinute == 80)
+        #expect(estimator.wordsPerLine == 10)
+        #expect(estimator.linesPerPage == 15)
+    }
+    
+    @Test
+    func testDefaultConfiguration() async {
+        // Arrange & Act
+        let estimator = FallbackGazeEstimator()
+        
+        // Assert - default reading speed should be reasonable for Arabic Quran reading
+        #expect(estimator.arabicWordsPerMinute >= 50)
+        #expect(estimator.arabicWordsPerMinute <= 120)
+    }
+    
+    // MARK: - Start/Stop Tests
+    
+    @Test
+    func testStartForPageActivatesEstimator() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        
+        // Assert
+        #expect(estimator.isActive == true)
+    }
+    
+    @Test
+    func testStopEstimatingDeactivates() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        estimator.startForPage(pageFrame: pageFrame)
+        
+        // Act
+        estimator.stopEstimating()
+        
+        // Assert
+        #expect(estimator.isActive == false)
+        #expect(estimator.estimatedGaze == nil)
+    }
+    
+    @Test
+    func testStartWhileActiveStopsFirst() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        let frame1 = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let frame2 = CGRect(x: 0, y: 0, width: 812, height: 375)
+        
+        estimator.startForPage(pageFrame: frame1)
+        
+        // Act
+        estimator.startForPage(pageFrame: frame2)
+        
+        // Assert
+        #expect(estimator.isActive == true)
+    }
+    
+    // MARK: - Gaze Estimation Tests
+    
+    @Test
+    func testEstimatedGazeGeneratedAfterStart() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        
+        // Wait for timer to fire
+        try? await Task.sleep(nanoseconds: 300_000_000)  // 0.3 seconds
+        
+        // Assert
+        #expect(estimator.estimatedGaze != nil)
+    }
+    
+    @Test
+    func testEstimatedGazeStartsAtTopOfPage() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        // Assert
+        let gaze = estimator.estimatedGaze
+        #expect(gaze != nil)
+        // Y position should be near the top (first line)
+        #expect(gaze!.screenPosition.y < 200)
+    }
+    
+    @Test
+    func testEstimatedGazeProgressesOverTime() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        estimator.arabicWordsPerMinute = 600  // Very fast for testing
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        let firstGaze = estimator.estimatedGaze
+        
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        let secondGaze = estimator.estimatedGaze
+        
+        // Assert - Y position should increase (moving down the page)
+        #expect(firstGaze != nil)
+        #expect(secondGaze != nil)
+        #expect(secondGaze!.screenPosition.y > firstGaze!.screenPosition.y)
+    }
+    
+    @Test
+    func testEstimatedGazeRTLDirection() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        estimator.arabicWordsPerMinute = 600  // Fast for testing
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        let firstGaze = estimator.estimatedGaze
+        
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        let secondGaze = estimator.estimatedGaze
+        
+        // Assert - X position should decrease (RTL: moving from right to left)
+        #expect(firstGaze != nil)
+        #expect(secondGaze != nil)
+        // Within same line, X should move left (decrease)
+        if firstGaze!.screenPosition.y == secondGaze!.screenPosition.y {
+            #expect(secondGaze!.screenPosition.x <= firstGaze!.screenPosition.x)
+        }
+    }
+    
+    // MARK: - Reading Speed Configuration Tests
+    
+    @Test
+    func testChangingReadingSpeedAffectsEstimation() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Test with slow reading speed
+        estimator.arabicWordsPerMinute = 40
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        let slowGaze = estimator.estimatedGaze
+        estimator.stopEstimating()
+        
+        // Test with fast reading speed
+        estimator.arabicWordsPerMinute = 200
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        let fastGaze = estimator.estimatedGaze
+        
+        // Assert - faster reading should progress further down the page
+        #expect(slowGaze != nil)
+        #expect(fastGaze != nil)
+        #expect(fastGaze!.screenPosition.y > slowGaze!.screenPosition.y)
+    }
+    
+    @Test
+    func testWordsPerLineConfiguration() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        
+        // Act
+        estimator.wordsPerLine = 12
+        
+        // Assert
+        #expect(estimator.wordsPerLine == 12)
+    }
+    
+    // MARK: - Pause/Resume Tests
+    
+    @Test
+    func testPauseStopsProgressionTemporarily() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        estimator.arabicWordsPerMinute = 600  // Fast for testing
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        let beforePause = estimator.estimatedGaze
+        
+        estimator.pause()
+        try? await Task.sleep(nanoseconds: 500_000_000)  // Paused for 0.5s
+        let duringPause = estimator.estimatedGaze
+        
+        // Assert - position should not change significantly during pause
+        #expect(beforePause != nil)
+        #expect(duringPause != nil)
+        // Allow small difference due to timer updates
+        let yDiff = abs(duringPause!.screenPosition.y - beforePause!.screenPosition.y)
+        #expect(yDiff < 50)  // Should be minimal movement
+    }
+    
+    @Test
+    func testResumeAfterPauseContinuesProgression() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        estimator.arabicWordsPerMinute = 600
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        estimator.pause()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        estimator.resume()
+        
+        let afterResume = estimator.estimatedGaze
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        let afterMoreTime = estimator.estimatedGaze
+        
+        // Assert - should continue progressing after resume
+        #expect(afterResume != nil)
+        #expect(afterMoreTime != nil)
+        #expect(afterMoreTime!.screenPosition.y > afterResume!.screenPosition.y)
+    }
+    
+    @Test
+    func testMultiplePauseResumeCycles() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        estimator.arabicWordsPerMinute = 600
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        
+        // First pause/resume
+        estimator.pause()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        estimator.resume()
+        
+        // Second pause/resume
+        estimator.pause()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        estimator.resume()
+        
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        // Assert - should still be generating estimates
+        #expect(estimator.estimatedGaze != nil)
+        #expect(estimator.isActive == true)
+    }
+    
+    @Test
+    func testPauseWhenNotActiveDoesNothing() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        
+        // Act & Assert - should not crash
+        estimator.pause()
+        estimator.resume()
+    }
+    
+    // MARK: - Reset Timer Tests
+    
+    @Test
+    func testResetPageTimerRestartsFromBeginning() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        estimator.arabicWordsPerMinute = 600
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        let beforeReset = estimator.estimatedGaze
+        
+        estimator.resetPageTimer()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        let afterReset = estimator.estimatedGaze
+        
+        // Assert - after reset, should be back near the top
+        #expect(beforeReset != nil)
+        #expect(afterReset != nil)
+        #expect(afterReset!.screenPosition.y < beforeReset!.screenPosition.y)
+    }
+    
+    // MARK: - Confidence Calculation Tests
+    
+    @Test
+    func testConfidenceDecreasesOverTime() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        estimator.arabicWordsPerMinute = 80  // Normal speed
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        let earlyConfidence = estimator.estimatedGaze?.confidence
+        
+        try? await Task.sleep(nanoseconds: 2_000_000_000)  // 2 more seconds
+        let laterConfidence = estimator.estimatedGaze?.confidence
+        
+        // Assert - confidence should decrease over time
+        #expect(earlyConfidence != nil)
+        #expect(laterConfidence != nil)
+        #expect(laterConfidence! < earlyConfidence!)
+    }
+    
+    @Test
+    func testConfidenceHasMinimumValue() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        estimator.arabicWordsPerMinute = 600  // Fast to reach end quickly
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 3_000_000_000)  // 3 seconds
+        
+        // Assert - confidence should not go below minimum (0.3)
+        let confidence = estimator.estimatedGaze?.confidence
+        #expect(confidence != nil)
+        #expect(confidence! >= 0.3)
+    }
+    
+    // MARK: - Geometry Update Tests
+    
+    @Test
+    func testUpdateGeometryDuringEstimation() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        let portraitFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        estimator.startForPage(pageFrame: portraitFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        // Act - rotate to landscape
+        let landscapeFrame = CGRect(x: 0, y: 0, width: 812, height: 375)
+        estimator.updateGeometry(frame: landscapeFrame)
+        
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        // Assert - should still be generating estimates with new geometry
+        #expect(estimator.estimatedGaze != nil)
+        #expect(estimator.isActive == true)
+    }
+    
+    // MARK: - Edge Cases
+    
+    @Test
+    func testStopWhenNotActiveDoesNotCrash() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        
+        // Act & Assert - should not crash
+        estimator.stopEstimating()
+        #expect(estimator.isActive == false)
+    }
+    
+    @Test
+    func testZeroWidthFrameDoesNotCrash() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        let zeroFrame = CGRect(x: 0, y: 0, width: 0, height: 812)
+        
+        // Act & Assert - should not crash
+        estimator.startForPage(pageFrame: zeroFrame)
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        // Estimator should handle gracefully
+        #expect(estimator.isActive == true)
+    }
+    
+    @Test
+    func testEstimationDoesNotExceedPageBounds() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        estimator.arabicWordsPerMinute = 1200  // Very fast
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act
+        estimator.startForPage(pageFrame: pageFrame)
+        try? await Task.sleep(nanoseconds: 5_000_000_000)  // 5 seconds - should finish page
+        
+        // Assert - should clamp to last line
+        let gaze = estimator.estimatedGaze
+        #expect(gaze != nil)
+        // Y should not exceed page bounds
+        #expect(gaze!.screenPosition.y <= pageFrame.maxY)
+    }
+    
+    @Test
+    func testNegativeTimeHandledGracefully() async {
+        // Arrange
+        let estimator = FallbackGazeEstimator()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        // Act - start, pause immediately, then resume
+        estimator.startForPage(pageFrame: pageFrame)
+        estimator.pause()
+        estimator.resume()
+        
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        
+        // Assert - should handle edge case without crashing
+        #expect(estimator.estimatedGaze != nil)
+    }
+}

--- a/Tests/MushafImadSPMTests/GazeToVerseMapperTests.swift
+++ b/Tests/MushafImadSPMTests/GazeToVerseMapperTests.swift
@@ -1,0 +1,804 @@
+import Foundation
+import Testing
+import CoreGraphics
+@testable import MushafImad
+
+/// Tests for GazeToVerseMapper to ensure gaze point to verse mapping works correctly
+/// across different screen sizes, orientations, and edge cases.
+@Suite(.serialized)
+@MainActor
+struct GazeToVerseMapperTests {
+    
+    // MARK: - Test Helpers
+    
+    /// Create a mock verse with highlights on specified lines
+    private func makeMockVerse(
+        id: Int,
+        number: Int,
+        highlights: [(line: Int, left: Float, right: Float)]
+    ) -> Verse {
+        let verse = Verse()
+        verse.verseID = id
+        verse.number = number
+        verse.text = "Mock verse \(number)"
+        
+        for highlight in highlights {
+            let h = VerseHighlight()
+            h.line = highlight.line
+            h.left = highlight.left
+            h.right = highlight.right
+            verse.highlights1441.append(h)
+        }
+        
+        return verse
+    }
+    
+    /// Create a mock gaze point at specified screen position
+    private func makeGazePoint(
+        x: CGFloat,
+        y: CGFloat,
+        confidence: Float = 0.9
+    ) -> GazePoint {
+        return GazePoint(
+            screenPosition: CGPoint(x: x, y: y),
+            confidence: confidence,
+            timestamp: CACurrentMediaTime()
+        )
+    }
+    
+    // MARK: - Basic Mapping Tests
+    
+    @Test
+    func testMapGazeToFirstLine() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        // Create a verse on line 0 spanning the full width (RTL: left=0, right=1)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        // Gaze at the center of the first line
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight / 2
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 0)
+        #expect(result?.verseID == 1)
+        #expect(result?.confidence == 0.9)
+    }
+    
+    @Test
+    func testMapGazeToMiddleLine() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        // Create a verse on line 7 (middle of page)
+        let verse = makeMockVerse(id: 2, number: 2, highlights: [(line: 7, left: 0.0, right: 1.0)])
+        
+        // Gaze at line 7
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight * 7.5
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 7)
+        #expect(result?.verseID == 2)
+    }
+    
+    @Test
+    func testMapGazeToLastLine() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        // Create a verse on line 14 (last line)
+        let verse = makeMockVerse(id: 3, number: 3, highlights: [(line: 14, left: 0.0, right: 1.0)])
+        
+        // Gaze at line 14
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight * 14.5
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 14)
+        #expect(result?.verseID == 3)
+    }
+
+    
+    // MARK: - Edge Cases: Out of Bounds
+    
+    @Test
+    func testGazeAbovePageReturnsNil() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 100, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        // Gaze above the page frame
+        let gazePoint = makeGazePoint(x: 187.5, y: 50)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result == nil)
+    }
+    
+    @Test
+    func testGazeBelowPageReturnsNil() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        // Gaze below the page frame
+        let gazePoint = makeGazePoint(x: 187.5, y: 900)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result == nil)
+    }
+    
+    @Test
+    func testGazeLeftOfPageReturnsNil() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 50, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        // Gaze to the left of the page frame
+        let gazePoint = makeGazePoint(x: 25, y: 100)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result == nil)
+    }
+    
+    @Test
+    func testGazeRightOfPageReturnsNil() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        // Gaze to the right of the page frame
+        let gazePoint = makeGazePoint(x: 400, y: 100)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result == nil)
+    }
+    
+    @Test
+    func testGazeInHeaderRegionReturnsNil() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        // Gaze in the header region (before line content starts)
+        let gazePoint = makeGazePoint(x: 187.5, y: 20)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result == nil)
+    }
+    
+    @Test
+    func testGazeInFooterRegionReturnsNil() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        // Gaze below all 15 lines (in footer region)
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let footerY = headerOffset + lineHeight * 15 + 10
+        let gazePoint = makeGazePoint(x: 187.5, y: footerY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result == nil)
+    }
+
+    
+    // MARK: - Edge Cases: Nil Scenarios
+    
+    @Test
+    func testEmptyVersesArrayReturnsResultWithoutVerseID() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        // Gaze at a valid position but with no verses
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight * 5.5
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 5)
+        #expect(result?.verseID == nil)
+    }
+    
+    @Test
+    func testNoMatchingVerseOnLineReturnsNilVerseID() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        // Create a verse on line 0, but gaze at line 5
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight * 5.5
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 5)
+        #expect(result?.verseID == nil)
+    }
+    
+    @Test
+    func testZeroLineHeightReturnsNil() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        // Don't call updatePageGeometry, so lineHeight remains 0
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        let gazePoint = makeGazePoint(x: 187.5, y: 100)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result == nil)
+    }
+
+    
+    // MARK: - Different Screen Sizes
+    
+    @Test
+    func testMappingOnSmallScreen() async {
+        // Arrange - iPhone SE size
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 320, height: 568)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 3, left: 0.0, right: 1.0)])
+        
+        // Gaze at line 3
+        let lineHeight = (320.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight * 3.5
+        let gazePoint = makeGazePoint(x: 160, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 3)
+        #expect(result?.verseID == 1)
+    }
+    
+    @Test
+    func testMappingOnLargeScreen() async {
+        // Arrange - iPad Pro size
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 1024, height: 1366)
+        let headerOffset: CGFloat = 60
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 10, left: 0.0, right: 1.0)])
+        
+        // Gaze at line 10
+        let lineHeight = (1024.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight * 10.5
+        let gazePoint = makeGazePoint(x: 512, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 10)
+        #expect(result?.verseID == 1)
+    }
+    
+    @Test
+    func testMappingOnStandardScreen() async {
+        // Arrange - iPhone 14 Pro size
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 393, height: 852)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 7, left: 0.0, right: 1.0)])
+        
+        // Gaze at line 7
+        let lineHeight = (393.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight * 7.5
+        let gazePoint = makeGazePoint(x: 196.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 7)
+        #expect(result?.verseID == 1)
+    }
+
+    
+    // MARK: - Different Orientations
+    
+    @Test
+    func testMappingInPortraitOrientation() async {
+        // Arrange - Portrait (tall and narrow)
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let headerOffset: CGFloat = 40
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.0, right: 1.0)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight * 5.5
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 5)
+        #expect(result?.verseID == 1)
+    }
+    
+    @Test
+    func testMappingInLandscapeOrientation() async {
+        // Arrange - Landscape (wide and short)
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 812, height: 375)
+        let headerOffset: CGFloat = 30
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: headerOffset)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 8, left: 0.0, right: 1.0)])
+        
+        let lineHeight = (812.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = headerOffset + lineHeight * 8.5
+        let gazePoint = makeGazePoint(x: 406, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 8)
+        #expect(result?.verseID == 1)
+    }
+    
+    @Test
+    func testGeometryUpdateHandlesOrientationChange() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.0, right: 1.0)])
+        
+        // Start in portrait
+        let portraitFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: portraitFrame, headerOffset: 40)
+        
+        let portraitLineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let portraitGazeY = 40 + portraitLineHeight * 5.5
+        let portraitGaze = makeGazePoint(x: 187.5, y: portraitGazeY)
+        
+        let portraitResult = mapper.mapGazeToVerse(gazePoint: portraitGaze, verses: [verse])
+        
+        // Rotate to landscape
+        let landscapeFrame = CGRect(x: 0, y: 0, width: 812, height: 375)
+        mapper.updatePageGeometry(frame: landscapeFrame, headerOffset: 30)
+        
+        let landscapeLineHeight = (812.0 / 1440.0 * 232.0) * 0.73
+        let landscapeGazeY = 30 + landscapeLineHeight * 5.5
+        let landscapeGaze = makeGazePoint(x: 406, y: landscapeGazeY)
+        
+        let landscapeResult = mapper.mapGazeToVerse(gazePoint: landscapeGaze, verses: [verse])
+        
+        // Assert both orientations work correctly
+        #expect(portraitResult?.lineIndex == 5)
+        #expect(portraitResult?.verseID == 1)
+        #expect(landscapeResult?.lineIndex == 5)
+        #expect(landscapeResult?.verseID == 1)
+    }
+
+    
+    // MARK: - RTL Layout and Verse Matching
+    
+    @Test
+    func testRTLLayoutVerseMatchingLeftSide() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        // RTL: left=0.5, right=1.0 means visual left side (0.0-0.5 in screen coords)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 2, left: 0.5, right: 1.0)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = 40 + lineHeight * 2.5
+        // Gaze at visual left (x = 25% of width)
+        let gazePoint = makeGazePoint(x: 93.75, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 2)
+        #expect(result?.verseID == 1)
+    }
+    
+    @Test
+    func testRTLLayoutVerseMatchingRightSide() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        // RTL: left=0.0, right=0.5 means visual right side (0.5-1.0 in screen coords)
+        let verse = makeMockVerse(id: 2, number: 2, highlights: [(line: 2, left: 0.0, right: 0.5)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = 40 + lineHeight * 2.5
+        // Gaze at visual right (x = 75% of width)
+        let gazePoint = makeGazePoint(x: 281.25, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result?.lineIndex == 2)
+        #expect(result?.verseID == 2)
+    }
+    
+    @Test
+    func testMultipleVersesOnSameLineSelectsCorrectOne() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        // Two verses on line 4: verse 1 on left half, verse 2 on right half (RTL)
+        let verse1 = makeMockVerse(id: 1, number: 1, highlights: [(line: 4, left: 0.5, right: 1.0)])
+        let verse2 = makeMockVerse(id: 2, number: 2, highlights: [(line: 4, left: 0.0, right: 0.5)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = 40 + lineHeight * 4.5
+        
+        // Gaze at left side (should hit verse 1)
+        let leftGaze = makeGazePoint(x: 93.75, y: gazeY)
+        let leftResult = mapper.mapGazeToVerse(gazePoint: leftGaze, verses: [verse1, verse2])
+        
+        // Gaze at right side (should hit verse 2)
+        let rightGaze = makeGazePoint(x: 281.25, y: gazeY)
+        let rightResult = mapper.mapGazeToVerse(gazePoint: rightGaze, verses: [verse1, verse2])
+        
+        // Assert
+        #expect(leftResult?.verseID == 1)
+        #expect(rightResult?.verseID == 2)
+    }
+    
+    @Test
+    func testVerseSpanningMultipleLinesMatchesCorrectly() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        // Verse spans lines 3, 4, and 5
+        let verse = makeMockVerse(
+            id: 1,
+            number: 1,
+            highlights: [
+                (line: 3, left: 0.0, right: 0.6),
+                (line: 4, left: 0.0, right: 1.0),
+                (line: 5, left: 0.4, right: 1.0)
+            ]
+        )
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        
+        // Test gaze on each line
+        let gaze3 = makeGazePoint(x: 300, y: 40 + lineHeight * 3.5)
+        let gaze4 = makeGazePoint(x: 187.5, y: 40 + lineHeight * 4.5)
+        let gaze5 = makeGazePoint(x: 100, y: 40 + lineHeight * 5.5)
+        
+        let result3 = mapper.mapGazeToVerse(gazePoint: gaze3, verses: [verse])
+        let result4 = mapper.mapGazeToVerse(gazePoint: gaze4, verses: [verse])
+        let result5 = mapper.mapGazeToVerse(gazePoint: gaze5, verses: [verse])
+        
+        // Assert all three gazes map to the same verse
+        #expect(result3?.verseID == 1)
+        #expect(result4?.verseID == 1)
+        #expect(result5?.verseID == 1)
+        #expect(result3?.lineIndex == 3)
+        #expect(result4?.lineIndex == 4)
+        #expect(result5?.lineIndex == 5)
+    }
+
+    
+    // MARK: - Line Progress Calculation
+    
+    @Test
+    func testLineProgressAtTopOfLine() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.0, right: 1.0)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        // Gaze at the very top of line 5
+        let gazeY = 40 + lineHeight * 5.0
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result!.lineProgress < 0.1) // Near 0
+    }
+    
+    @Test
+    func testLineProgressAtBottomOfLine() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.0, right: 1.0)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        // Gaze at the very bottom of line 5
+        let gazeY = 40 + lineHeight * 5.99
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result!.lineProgress > 0.9) // Near 1
+    }
+    
+    @Test
+    func testLineProgressAtMiddleOfLine() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.0, right: 1.0)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        // Gaze at the middle of line 5
+        let gazeY = 40 + lineHeight * 5.5
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert
+        #expect(result != nil)
+        #expect(result!.lineProgress > 0.4 && result!.lineProgress < 0.6) // Around 0.5
+    }
+
+    
+    // MARK: - Confidence Propagation
+    
+    @Test
+    func testConfidenceIsPreservedFromGazePoint() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = 40 + lineHeight * 0.5
+        
+        // Test different confidence levels
+        let highConfidenceGaze = makeGazePoint(x: 187.5, y: gazeY, confidence: 0.95)
+        let mediumConfidenceGaze = makeGazePoint(x: 187.5, y: gazeY, confidence: 0.6)
+        let lowConfidenceGaze = makeGazePoint(x: 187.5, y: gazeY, confidence: 0.3)
+        
+        // Act
+        let highResult = mapper.mapGazeToVerse(gazePoint: highConfidenceGaze, verses: [verse])
+        let mediumResult = mapper.mapGazeToVerse(gazePoint: mediumConfidenceGaze, verses: [verse])
+        let lowResult = mapper.mapGazeToVerse(gazePoint: lowConfidenceGaze, verses: [verse])
+        
+        // Assert
+        #expect(highResult?.confidence == 0.95)
+        #expect(mediumResult?.confidence == 0.6)
+        #expect(lowResult?.confidence == 0.3)
+    }
+    
+    // MARK: - Fallback Estimation
+    
+    @Test
+    func testEstimateLineFromReadingTimeAtStart() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        
+        // Act - Just started reading (0 seconds)
+        let line = mapper.estimateLineFromReadingTime(
+            elapsedSeconds: 0,
+            wordsPerMinute: 80,
+            totalWordsOnPage: 150
+        )
+        
+        // Assert
+        #expect(line == 0)
+    }
+    
+    @Test
+    func testEstimateLineFromReadingTimeAtMiddle() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        
+        // Act - Read for enough time to be at middle of page
+        // 150 words / 80 wpm = 1.875 minutes = 112.5 seconds for full page
+        // Half page = 56.25 seconds
+        let line = mapper.estimateLineFromReadingTime(
+            elapsedSeconds: 56.25,
+            wordsPerMinute: 80,
+            totalWordsOnPage: 150
+        )
+        
+        // Assert - Should be around line 7 (middle of 15 lines)
+        #expect(line >= 6 && line <= 8)
+    }
+    
+    @Test
+    func testEstimateLineFromReadingTimeAtEnd() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        
+        // Act - Read for more than enough time to finish page
+        let line = mapper.estimateLineFromReadingTime(
+            elapsedSeconds: 200,
+            wordsPerMinute: 80,
+            totalWordsOnPage: 150
+        )
+        
+        // Assert - Should clamp to last line (14)
+        #expect(line == 14)
+    }
+    
+    @Test
+    func testEstimateLineFromReadingTimeWithFasterSpeed() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        
+        // Act - Fast reader (120 wpm) after 30 seconds
+        let line = mapper.estimateLineFromReadingTime(
+            elapsedSeconds: 30,
+            wordsPerMinute: 120,
+            totalWordsOnPage: 150
+        )
+        
+        // Assert - Should be further along than slower reader
+        #expect(line >= 4)
+    }
+    
+    // MARK: - Nearest Verse Fallback
+    
+    @Test
+    func testNearestVerseFallbackWhenGazeBetweenVerses() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        // Two verses with a gap between them on line 5
+        let verse1 = makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.7, right: 1.0)])
+        let verse2 = makeMockVerse(id: 2, number: 2, highlights: [(line: 5, left: 0.0, right: 0.3)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = 40 + lineHeight * 5.5
+        
+        // Gaze in the gap (normalized x around 0.5, which is between 0.3 and 0.7)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse1, verse2])
+        
+        // Assert - Should find nearest verse (within 10% threshold)
+        #expect(result != nil)
+        #expect(result?.verseID != nil)
+    }
+    
+    @Test
+    func testNoNearestVerseWhenTooFarAway() async {
+        // Arrange
+        let mapper = GazeToVerseMapper()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        mapper.updatePageGeometry(frame: pageFrame, headerOffset: 40)
+        
+        // Verse only on far right (RTL: left=0.0, right=0.1)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.0, right: 0.1)])
+        
+        let lineHeight = (375.0 / 1440.0 * 232.0) * 0.73
+        let gazeY = 40 + lineHeight * 5.5
+        
+        // Gaze on far left (normalized x = 0.05, visual position after RTL conversion)
+        let gazePoint = makeGazePoint(x: 18.75, y: gazeY)
+        
+        // Act
+        let result = mapper.mapGazeToVerse(gazePoint: gazePoint, verses: [verse])
+        
+        // Assert - Should still find line but verse might be nil or matched
+        #expect(result != nil)
+        #expect(result?.lineIndex == 5)
+    }
+}

--- a/Tests/MushafImadSPMTests/ReadingProgressTrackerTests.swift
+++ b/Tests/MushafImadSPMTests/ReadingProgressTrackerTests.swift
@@ -1,0 +1,702 @@
+import Foundation
+import Testing
+import CoreGraphics
+@testable import MushafImad
+
+/// Tests for ReadingProgressTracker to ensure dwell time detection, progress state transitions,
+/// and session tracking work correctly.
+@Suite(.serialized)
+@MainActor
+struct ReadingProgressTrackerTests {
+    
+    // MARK: - Test Helpers
+    
+    /// Create a mock verse with highlights
+    private func makeMockVerse(
+        id: Int,
+        chapterNumber: Int = 1,
+        number: Int,
+        highlights: [(line: Int, left: Float, right: Float)]
+    ) -> Verse {
+        let verse = Verse()
+        verse.verseID = id
+        verse.chapterNumber = chapterNumber
+        verse.number = number
+        verse.text = "Mock verse \(number)"
+        
+        for highlight in highlights {
+            let h = VerseHighlight()
+            h.line = highlight.line
+            h.left = highlight.left
+            h.right = highlight.right
+            verse.highlights1441.append(h)
+        }
+        
+        return verse
+    }
+    
+    /// Create a mock gaze point
+    private func makeGazePoint(
+        x: CGFloat,
+        y: CGFloat,
+        confidence: Float = 0.9
+    ) -> GazePoint {
+        return GazePoint(
+            screenPosition: CGPoint(x: x, y: y),
+            confidence: confidence,
+            timestamp: CACurrentMediaTime()
+        )
+    }
+    
+    /// Calculate Y position for a specific line
+    private func yPositionForLine(
+        _ lineIndex: Int,
+        pageWidth: CGFloat,
+        headerOffset: CGFloat
+    ) -> CGFloat {
+        let lineHeight = (pageWidth / 1440.0 * 232.0) * 0.73
+        return headerOffset + lineHeight * (CGFloat(lineIndex) + 0.5)
+    }
+    
+    // MARK: - Initialization Tests
+    
+    @Test
+    func testInitialState() async {
+        // Arrange & Act
+        let tracker = ReadingProgressTracker()
+        
+        // Assert
+        #expect(tracker.activeVerse == nil)
+        #expect(tracker.activeLineIndex == 0)
+        #expect(tracker.pageCompleted == false)
+        #expect(tracker.readingProgress == 0)
+        #expect(tracker.isTracking == false)
+        #expect(tracker.currentSession == nil)
+    }
+    
+    @Test
+    func testDefaultConfiguration() async {
+        // Arrange & Act
+        let tracker = ReadingProgressTracker()
+        
+        // Assert
+        #expect(tracker.dwellTimeThreshold == 1.5)
+        #expect(tracker.pageCompletionDwellTime == 3.0)
+        #expect(tracker.autoAdvanceEnabled == true)
+    }
+    
+    // MARK: - Start/Stop Tracking Tests
+    
+    @Test
+    func testStartTrackingSetsInitialState() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        ]
+        
+        // Act
+        tracker.startTracking(pageNumber: 1, verses: verses, pageFrame: pageFrame)
+        
+        // Assert
+        #expect(tracker.isTracking == true)
+        #expect(tracker.pageCompleted == false)
+        #expect(tracker.readingProgress == 0)
+        #expect(tracker.activeVerse == nil)
+        #expect(tracker.activeLineIndex == 0)
+    }
+    
+    @Test
+    func testStopTrackingResetsState() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        ]
+        
+        tracker.startTracking(pageNumber: 1, verses: verses, pageFrame: pageFrame)
+        
+        // Act
+        tracker.stopTracking()
+        
+        // Assert
+        #expect(tracker.isTracking == false)
+    }
+    
+    @Test
+    func testStartTrackingWhileAlreadyTrackingStopsFirst() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses1 = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        ]
+        let verses2 = [
+            makeMockVerse(id: 2, number: 2, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        ]
+        
+        tracker.startTracking(pageNumber: 1, verses: verses1, pageFrame: pageFrame)
+        
+        // Act
+        tracker.startTracking(pageNumber: 2, verses: verses2, pageFrame: pageFrame)
+        
+        // Assert
+        #expect(tracker.isTracking == true)
+    }
+    
+    // MARK: - Gaze Processing Tests
+    
+    @Test
+    func testProcessGazePointUpdatesActiveLineIndex() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.0, right: 1.0)])
+        ]
+        
+        tracker.startTracking(pageNumber: 1, verses: verses, pageFrame: pageFrame)
+        
+        // Create gaze point on line 5
+        let gazeY = yPositionForLine(5, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(tracker.activeLineIndex == 5)
+    }
+    
+    @Test
+    func testProcessGazePointUpdatesReadingProgress() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 7, left: 0.0, right: 1.0)])
+        ]
+        
+        tracker.startTracking(pageNumber: 1, verses: verses, pageFrame: pageFrame)
+        
+        // Create gaze point on line 7 (middle of page)
+        let gazeY = yPositionForLine(7, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        // Progress should be 7/14 = 0.5
+        #expect(tracker.readingProgress == 0.5)
+    }
+    
+    @Test
+    func testProcessGazePointOutsidePageDoesNotUpdateState() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        ]
+        
+        tracker.startTracking(pageNumber: 1, verses: verses, pageFrame: pageFrame)
+        
+        let initialLineIndex = tracker.activeLineIndex
+        let initialProgress = tracker.readingProgress
+        
+        // Create gaze point outside page
+        let gazePoint = makeGazePoint(x: 500, y: 100)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert - state should remain unchanged
+        #expect(tracker.activeLineIndex == initialLineIndex)
+        #expect(tracker.readingProgress == initialProgress)
+    }
+    
+    @Test
+    func testProcessGazePointWhenNotTrackingDoesNothing() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let gazePoint = makeGazePoint(x: 187.5, y: 100)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(tracker.activeLineIndex == 0)
+        #expect(tracker.readingProgress == 0)
+    }
+    
+    // MARK: - Dwell Time Detection Tests
+    
+    @Test
+    func testDwellTimeThresholdNotMetDoesNotSetActiveVerse() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.dwellTimeThreshold = 2.0  // 2 seconds
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Create gaze point on verse
+        let gazeY = yPositionForLine(0, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act - process gaze but don't wait for threshold
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(tracker.activeVerse == nil)
+    }
+    
+    @Test
+    func testDwellTimeThresholdMetSetsActiveVerse() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.dwellTimeThreshold = 0.1  // Very short for testing
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, chapterNumber: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Create gaze point on verse
+        let gazeY = yPositionForLine(0, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act - process gaze and wait for threshold
+        tracker.processGazePoint(gazePoint)
+        try? await Task.sleep(nanoseconds: 150_000_000)  // 0.15 seconds
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(tracker.activeVerse?.verseID == 1)
+    }
+    
+    @Test
+    func testMovingGazeToDifferentVerseResetsDwellTimer() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.dwellTimeThreshold = 0.1
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse1 = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        let verse2 = makeMockVerse(id: 2, number: 2, highlights: [(line: 1, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse1, verse2], pageFrame: pageFrame)
+        
+        // Gaze at verse 1
+        let gaze1Y = yPositionForLine(0, pageWidth: 375, headerOffset: 40)
+        let gaze1 = makeGazePoint(x: 187.5, y: gaze1Y)
+        tracker.processGazePoint(gaze1)
+        
+        try? await Task.sleep(nanoseconds: 50_000_000)  // 0.05 seconds (half threshold)
+        
+        // Move to verse 2 before threshold met
+        let gaze2Y = yPositionForLine(1, pageWidth: 375, headerOffset: 40)
+        let gaze2 = makeGazePoint(x: 187.5, y: gaze2Y)
+        tracker.processGazePoint(gaze2)
+        
+        // Assert - active verse should still be nil because dwell was reset
+        #expect(tracker.activeVerse == nil)
+    }
+    
+    @Test
+    func testActiveVerseChangedCallbackInvoked() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.dwellTimeThreshold = 0.1
+        
+        var callbackInvoked = false
+        var callbackVerse: Verse?
+        
+        tracker.onActiveVerseChanged = { verse in
+            callbackInvoked = true
+            callbackVerse = verse
+        }
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Create gaze point on verse
+        let gazeY = yPositionForLine(0, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(callbackInvoked == true)
+        #expect(callbackVerse?.verseID == 1)
+    }
+    
+    // MARK: - Page Completion Tests
+    
+    @Test
+    func testPageCompletionNotTriggeredOnEarlyLines() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.pageCompletionDwellTime = 0.1
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Gaze at line 5 (middle of page)
+        let gazeY = yPositionForLine(5, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(tracker.pageCompleted == false)
+    }
+    
+    @Test
+    func testPageCompletionTriggeredOnLastLine() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.pageCompletionDwellTime = 0.1
+        tracker.autoAdvanceEnabled = false  // Disable auto-advance for testing
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 14, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Gaze at line 14 (last line)
+        let gazeY = yPositionForLine(14, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(tracker.pageCompleted == true)
+        #expect(tracker.readingProgress == 1.0)
+    }
+    
+    @Test
+    func testPageCompletionCallbackInvoked() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.pageCompletionDwellTime = 0.1
+        tracker.autoAdvanceEnabled = true
+        
+        var callbackInvoked = false
+        tracker.onPageCompleted = {
+            callbackInvoked = true
+        }
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 14, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Gaze at last line
+        let gazeY = yPositionForLine(14, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(callbackInvoked == true)
+    }
+    
+    @Test
+    func testPageCompletionNotInvokedWhenAutoAdvanceDisabled() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.pageCompletionDwellTime = 0.1
+        tracker.autoAdvanceEnabled = false
+        
+        var callbackInvoked = false
+        tracker.onPageCompleted = {
+            callbackInvoked = true
+        }
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 14, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Gaze at last line
+        let gazeY = yPositionForLine(14, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(tracker.pageCompleted == true)
+        #expect(callbackInvoked == false)
+    }
+    
+    // MARK: - Pause/Resume Tests
+    
+    @Test
+    func testPauseTrackingRecordsPauseTime() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        ]
+        
+        tracker.startTracking(pageNumber: 1, verses: verses, pageFrame: pageFrame)
+        
+        // Act
+        tracker.pauseTracking()
+        try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1 seconds
+        tracker.resumeTracking()
+        
+        // Assert - session should account for paused time
+        tracker.stopTracking()
+        #expect(tracker.currentSession != nil)
+    }
+    
+    @Test
+    func testPauseWhenNotTrackingDoesNothing() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        
+        // Act & Assert - should not crash
+        tracker.pauseTracking()
+        tracker.resumeTracking()
+    }
+    
+    @Test
+    func testMultiplePauseResumeCycles() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        ]
+        
+        tracker.startTracking(pageNumber: 1, verses: verses, pageFrame: pageFrame)
+        
+        // Act - multiple pause/resume cycles
+        tracker.pauseTracking()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        tracker.resumeTracking()
+        
+        tracker.pauseTracking()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        tracker.resumeTracking()
+        
+        // Assert
+        tracker.stopTracking()
+        #expect(tracker.currentSession != nil)
+    }
+    
+    // MARK: - Session Tracking Tests
+    
+    @Test
+    func testSessionCreatedOnStopTracking() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, chapterNumber: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Process some gaze points
+        let gazeY = yPositionForLine(0, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY, confidence: 0.8)
+        tracker.processGazePoint(gazePoint)
+        
+        // Act
+        tracker.stopTracking()
+        
+        // Assert
+        #expect(tracker.currentSession != nil)
+        #expect(tracker.currentSession?.pageNumber == 1)
+    }
+    
+    @Test
+    func testSessionTracksAverageConfidence() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Process gaze points with different confidence levels
+        let gazeY = yPositionForLine(0, pageWidth: 375, headerOffset: 40)
+        tracker.processGazePoint(makeGazePoint(x: 187.5, y: gazeY, confidence: 0.8))
+        tracker.processGazePoint(makeGazePoint(x: 187.5, y: gazeY, confidence: 0.6))
+        tracker.processGazePoint(makeGazePoint(x: 187.5, y: gazeY, confidence: 1.0))
+        
+        // Act
+        tracker.stopTracking()
+        
+        // Assert - average should be (0.8 + 0.6 + 1.0) / 3 = 0.8
+        #expect(tracker.currentSession?.averageConfidence == 0.8)
+    }
+    
+    @Test
+    func testSessionTracksCompletionStatus() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.pageCompletionDwellTime = 0.1
+        tracker.autoAdvanceEnabled = false
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 14, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Complete the page
+        let gazeY = yPositionForLine(14, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        tracker.processGazePoint(gazePoint)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        tracker.processGazePoint(gazePoint)
+        
+        // Act
+        tracker.stopTracking()
+        
+        // Assert
+        #expect(tracker.currentSession?.completedPage == true)
+    }
+    
+    @Test
+    func testSessionTracksTrackingMethod() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        tracker.trackingMethod = .fallback
+        
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        ]
+        
+        tracker.startTracking(pageNumber: 1, verses: verses, pageFrame: pageFrame)
+        
+        // Act
+        tracker.stopTracking()
+        
+        // Assert
+        #expect(tracker.currentSession?.trackingMethod == .fallback)
+    }
+    
+    // MARK: - Geometry Update Tests
+    
+    @Test
+    func testUpdateGeometryAllowsGazeProcessingAfterRotation() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let portraitFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 5, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: portraitFrame)
+        
+        // Rotate to landscape
+        let landscapeFrame = CGRect(x: 0, y: 0, width: 812, height: 375)
+        tracker.updateGeometry(frame: landscapeFrame)
+        
+        // Create gaze point for landscape orientation
+        let gazeY = yPositionForLine(5, pageWidth: 812, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 406, y: gazeY)
+        
+        // Act
+        tracker.processGazePoint(gazePoint)
+        
+        // Assert
+        #expect(tracker.activeLineIndex == 5)
+    }
+    
+    // MARK: - Edge Cases
+    
+    @Test
+    func testProcessingGazeOnLineWithoutVerseDoesNotCrash() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        // Verse on line 0, but we'll gaze at line 5
+        let verse = makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        
+        tracker.startTracking(pageNumber: 1, verses: [verse], pageFrame: pageFrame)
+        
+        // Gaze at line 5 (no verse there)
+        let gazeY = yPositionForLine(5, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        
+        // Act & Assert - should not crash
+        tracker.processGazePoint(gazePoint)
+        #expect(tracker.activeLineIndex == 5)
+        #expect(tracker.activeVerse == nil)
+    }
+    
+    @Test
+    func testEmptyVersesArrayDoesNotCrash() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        
+        tracker.startTracking(pageNumber: 1, verses: [], pageFrame: pageFrame)
+        
+        // Act & Assert - should not crash
+        let gazeY = yPositionForLine(5, pageWidth: 375, headerOffset: 40)
+        let gazePoint = makeGazePoint(x: 187.5, y: gazeY)
+        tracker.processGazePoint(gazePoint)
+        
+        #expect(tracker.activeVerse == nil)
+    }
+    
+    @Test
+    func testStopTrackingWhenNotTrackingDoesNotCrash() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        
+        // Act & Assert - should not crash
+        tracker.stopTracking()
+        #expect(tracker.isTracking == false)
+    }
+    
+    @Test
+    func testConfigurationCanBeChangedDuringTracking() async {
+        // Arrange
+        let tracker = ReadingProgressTracker()
+        let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let verses = [
+            makeMockVerse(id: 1, number: 1, highlights: [(line: 0, left: 0.0, right: 1.0)])
+        ]
+        
+        tracker.startTracking(pageNumber: 1, verses: verses, pageFrame: pageFrame)
+        
+        // Act - change configuration during tracking
+        tracker.dwellTimeThreshold = 0.5
+        tracker.pageCompletionDwellTime = 2.0
+        tracker.autoAdvanceEnabled = false
+        
+        // Assert - should not crash and values should be updated
+        #expect(tracker.dwellTimeThreshold == 0.5)
+        #expect(tracker.pageCompletionDwellTime == 2.0)
+        #expect(tracker.autoAdvanceEnabled == false)
+    }
+}


### PR DESCRIPTION
Closes #22

Implements an experimental, privacy-first eye tracking system that detects which verse the user is currently reading, automatically saves reading progress, and optionally advances to the next page.

### Core components:
- **EyeTrackingService**: ARKit TrueDepth gaze estimation with smoothing
- **GazeToVerseMapper**: Maps screen coordinates to Mushaf verses, supporting RTL bounding boxes
- **FallbackGazeEstimator**: Time-based heuristic for non-TrueDepth devices
- **ReadingProgressTracker**: Orchestrates dwell detection, active verse tracking, and auto-advance logic
- **ReadingSession**: SwiftData model for persistence
- **EyeTrackingSettingsView**: Full settings panel for tuning params and enabling experimental features

All camera data processing occurs on-device, prioritizing privacy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental eye-tracking using device camera for live gaze, smoothing, and face-loss handling.
  * On-page overlay: animated gaze dot, pulsing ring, vertical progress bar, active-verse badge, and status indicator.
  * Settings screen to enable/configure tracking, tuning (dwell time, reading speed), overlay, fallback mode, and privacy info.
  * Fallback gaze estimation for unsupported devices.
  * Reading-progress sessions persisted with auto-advance, resume support, and per-page activation via page geometry.
  * Toolbar control to open eye-tracking settings and toggle overlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->