### PR TITLE
Decouple reading theme from system appearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ MushafView(initialPage: 1)
     )
 ```
 
+Theme resolution in `MushafView` follows this precedence: `explicitReadingTheme ?? environmentReadingTheme ?? readingThemePreset.theme` (an explicit per-instance `readingTheme` passed to `MushafView` wins first, then any package-level/environment-provided theme, and finally the persisted preset default).
+
 ```swift
 struct ReaderContainer: View {
     @State private var highlightedVerse: Verse?

--- a/README.md
+++ b/README.md
@@ -169,8 +169,28 @@ If your app already has a `ModelContainer`, simply add `ReadingSession.self` to 
 4. **Optional configuration**
    - Use `AppStorage` keys (`reading_theme`, `scrolling_mode`, `selectedReciterId`) to persist user preferences.
    - Add `ToastOverlayView()` at the root of your layout so toasts can appear above the UI.
-   - Customize colors via assets or override `ReadingTheme` cases if you add more themes.
+   - Keep reading colors stable across system Light/Dark by providing a custom `ReadingTheme`.
    - React to user interaction with `onVerseLongPress` and `onPageTap` to drive surrounding UI, such as showing toolbars or presenting sheets.
+
+```swift
+// Per-instance reading theme override
+MushafView(
+    initialPage: 1,
+    readingTheme: ReadingTheme(
+        backgroundColor: Color(hex: "#F6F0DF"),
+        textColor: .naturalBlack
+    )
+)
+
+// Or set a package-level default for a subtree
+MushafView(initialPage: 1)
+    .mushafReadingTheme(
+        ReadingTheme(
+            backgroundColor: Color(hex: "#1F2420"),
+            textColor: .naturalWhite
+        )
+    )
+```
 
 ```swift
 struct ReaderContainer: View {

--- a/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
+++ b/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
@@ -140,7 +140,6 @@ public struct QuranPlayer: View {
             )
             .presentationDetents([.height(280)])
             .presentationDragIndicator(.visible)
-            .environment(\.colorScheme, .light)
         }
     }
     

--- a/Sources/MushafImad/Core/Models/ReadingTheme.swift
+++ b/Sources/MushafImad/Core/Models/ReadingTheme.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// A complete reading appearance definition used by `MushafView`.
-public struct ReadingTheme {
+public struct ReadingTheme: Equatable {
     public let backgroundColor: Color
     public let textColor: Color
 
@@ -38,7 +38,7 @@ public struct ReadingTheme {
     )
 }
 
-/// Built-in reading theme presets persisted by `AppStorage("reading_theme")`.
+/// Built-in theme presets suitable for persistence in `AppStorage`.
 public enum ReadingThemePreset: String, CaseIterable {
     case comfortable
     case calm
@@ -72,86 +72,12 @@ public enum ReadingThemePreset: String, CaseIterable {
     }
 }
 
-private struct MushafReadingThemeEnvironmentKey: EnvironmentKey {
-    static let defaultValue: ReadingTheme? = nil
-}
-
-public extension EnvironmentValues {
-    /// Optional package-level reading theme override for `MushafView`.
-    var mushafReadingTheme: ReadingTheme? {
-        get { self[MushafReadingThemeEnvironmentKey.self] }
-        set { self[MushafReadingThemeEnvironmentKey.self] = newValue }
-    }
-}
-
-public extension View {
-    /// Sets a subtree-wide reading theme for `MushafView` instances.
-    func mushafReadingTheme(_ theme: ReadingTheme?) -> some View {
-        environment(\.mushafReadingTheme, theme)
-    }
-}
-//
-//  ReadingTheme.swift
-//  MushafImad
-//
-//  Created by Assistant on 07/04/2026.
-//
-
-import SwiftUI
-
-/// Defines the visual appearance of the Mushaf reading surface.
-///
-/// This model is intentionally independent from system light/dark mode so the
-/// reading experience can remain stable based on user preference.
-public struct ReadingTheme: Equatable {
-    public let backgroundColor: Color
-    public let textColor: Color
-
-    public init(backgroundColor: Color, textColor: Color) {
-        self.backgroundColor = backgroundColor
-        self.textColor = textColor
-    }
-}
-
-/// Built-in theme presets suitable for persistence in `AppStorage`.
-public enum ReadingThemePreset: String, CaseIterable {
-    case comfortable
-    case calm
-    case night
-    case white
-
-    public var theme: ReadingTheme {
-        switch self {
-        case .comfortable:
-            ReadingTheme(backgroundColor: Color(hex: "#E4EFD9"), textColor: .naturalBlack)
-        case .calm:
-            ReadingTheme(backgroundColor: Color(hex: "#E0F1EA"), textColor: .naturalBlack)
-        case .night:
-            ReadingTheme(backgroundColor: Color(hex: "#2F352F"), textColor: .naturalWhite)
-        case .white:
-            ReadingTheme(backgroundColor: Color(hex: "#FFFFFF"), textColor: .naturalBlack)
-        }
-    }
-
-    public var title: String {
-        switch self {
-        case .comfortable:
-            String(localized: "Comfy")
-        case .calm:
-            String(localized: "Calm")
-        case .night:
-            String(localized: "Night")
-        case .white:
-            String(localized: "White")
-        }
-    }
-}
-
 private struct MushafReadingThemeKey: EnvironmentKey {
     static let defaultValue: ReadingTheme? = nil
 }
 
 public extension EnvironmentValues {
+    /// Optional package-level reading theme override for `MushafView`.
     var mushafReadingTheme: ReadingTheme? {
         get { self[MushafReadingThemeKey.self] }
         set { self[MushafReadingThemeKey.self] = newValue }
@@ -159,8 +85,8 @@ public extension EnvironmentValues {
 }
 
 public extension View {
-    /// Sets a package-level reading theme for `MushafView` descendants.
-    func mushafReadingTheme(_ theme: ReadingTheme) -> some View {
+    /// Sets a subtree-wide reading theme for `MushafView` instances.
+    func mushafReadingTheme(_ theme: ReadingTheme?) -> some View {
         environment(\.mushafReadingTheme, theme)
     }
 }

--- a/Sources/MushafImad/Core/Models/ReadingTheme.swift
+++ b/Sources/MushafImad/Core/Models/ReadingTheme.swift
@@ -1,0 +1,166 @@
+//
+//  ReadingTheme.swift
+//  MushafImad
+//
+//  Reading appearance model that stays independent from the system color scheme.
+//
+
+import SwiftUI
+
+/// A complete reading appearance definition used by `MushafView`.
+public struct ReadingTheme {
+    public let backgroundColor: Color
+    public let textColor: Color
+
+    public init(backgroundColor: Color, textColor: Color) {
+        self.backgroundColor = backgroundColor
+        self.textColor = textColor
+    }
+
+    public static let comfortable = ReadingTheme(
+        backgroundColor: Color(hex: "#E4EFD9"),
+        textColor: .naturalBlack
+    )
+
+    public static let calm = ReadingTheme(
+        backgroundColor: Color(hex: "#E0F1EA"),
+        textColor: .naturalBlack
+    )
+
+    public static let night = ReadingTheme(
+        backgroundColor: Color(hex: "#2F352F"),
+        textColor: .naturalWhite
+    )
+
+    public static let white = ReadingTheme(
+        backgroundColor: Color(hex: "#FFFFFF"),
+        textColor: .naturalBlack
+    )
+}
+
+/// Built-in reading theme presets persisted by `AppStorage("reading_theme")`.
+public enum ReadingThemePreset: String, CaseIterable {
+    case comfortable
+    case calm
+    case night
+    case white
+
+    public var theme: ReadingTheme {
+        switch self {
+        case .comfortable:
+            .comfortable
+        case .calm:
+            .calm
+        case .night:
+            .night
+        case .white:
+            .white
+        }
+    }
+
+    public var title: String {
+        switch self {
+        case .comfortable:
+            String(localized: "Comfy")
+        case .calm:
+            String(localized: "Calm")
+        case .night:
+            String(localized: "Night")
+        case .white:
+            String(localized: "White")
+        }
+    }
+}
+
+private struct MushafReadingThemeEnvironmentKey: EnvironmentKey {
+    static let defaultValue: ReadingTheme? = nil
+}
+
+public extension EnvironmentValues {
+    /// Optional package-level reading theme override for `MushafView`.
+    var mushafReadingTheme: ReadingTheme? {
+        get { self[MushafReadingThemeEnvironmentKey.self] }
+        set { self[MushafReadingThemeEnvironmentKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Sets a subtree-wide reading theme for `MushafView` instances.
+    func mushafReadingTheme(_ theme: ReadingTheme?) -> some View {
+        environment(\.mushafReadingTheme, theme)
+    }
+}
+//
+//  ReadingTheme.swift
+//  MushafImad
+//
+//  Created by Assistant on 07/04/2026.
+//
+
+import SwiftUI
+
+/// Defines the visual appearance of the Mushaf reading surface.
+///
+/// This model is intentionally independent from system light/dark mode so the
+/// reading experience can remain stable based on user preference.
+public struct ReadingTheme: Equatable {
+    public let backgroundColor: Color
+    public let textColor: Color
+
+    public init(backgroundColor: Color, textColor: Color) {
+        self.backgroundColor = backgroundColor
+        self.textColor = textColor
+    }
+}
+
+/// Built-in theme presets suitable for persistence in `AppStorage`.
+public enum ReadingThemePreset: String, CaseIterable {
+    case comfortable
+    case calm
+    case night
+    case white
+
+    public var theme: ReadingTheme {
+        switch self {
+        case .comfortable:
+            ReadingTheme(backgroundColor: Color(hex: "#E4EFD9"), textColor: .naturalBlack)
+        case .calm:
+            ReadingTheme(backgroundColor: Color(hex: "#E0F1EA"), textColor: .naturalBlack)
+        case .night:
+            ReadingTheme(backgroundColor: Color(hex: "#2F352F"), textColor: .naturalWhite)
+        case .white:
+            ReadingTheme(backgroundColor: Color(hex: "#FFFFFF"), textColor: .naturalBlack)
+        }
+    }
+
+    public var title: String {
+        switch self {
+        case .comfortable:
+            String(localized: "Comfy")
+        case .calm:
+            String(localized: "Calm")
+        case .night:
+            String(localized: "Night")
+        case .white:
+            String(localized: "White")
+        }
+    }
+}
+
+private struct MushafReadingThemeKey: EnvironmentKey {
+    static let defaultValue: ReadingTheme? = nil
+}
+
+public extension EnvironmentValues {
+    var mushafReadingTheme: ReadingTheme? {
+        get { self[MushafReadingThemeKey.self] }
+        set { self[MushafReadingThemeKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Sets a package-level reading theme for `MushafView` descendants.
+    func mushafReadingTheme(_ theme: ReadingTheme) -> some View {
+        environment(\.mushafReadingTheme, theme)
+    }
+}

--- a/Sources/MushafImad/MushafView.swift
+++ b/Sources/MushafImad/MushafView.swift
@@ -8,40 +8,6 @@
 import SwiftUI
 import SwiftData
 
-/// User-selectable background palettes that match the reading mood.
-public enum ReadingTheme: String, CaseIterable {
-    case comfortable
-    case calm
-    case night
-    case white
-
-    public var color: Color {
-        switch self {
-        case .comfortable:
-            return Color(hex: "#E4EFD9")
-        case .calm:
-            return Color(hex: "#E0F1EA")
-        case .night:
-            return Color(hex: "#2F352F")
-        case .white:
-            return Color(hex: "#FFFFFF")
-        }
-    }
-
-    public var title: String {
-        switch self {
-        case .comfortable:
-            String(localized: "Comfy")
-        case .calm:
-            String(localized: "Calm")
-        case .night:
-            String(localized: "Night")
-        case .white:
-            String(localized: "White")
-        }
-    }
-}
-
 /// Controls whether the reader shows image-based pages or text-based verses.
 public enum DisplayMode: String, CaseIterable {
     case image
@@ -72,6 +38,7 @@ public struct MushafView: View {
     private let highlightedVerseBinding: Binding<Verse?>?
     private let externalLongPressHandler: ((Verse) -> Void)?
     private let externalPageTapHandler: (() -> Void)?
+    private let explicitReadingTheme: ReadingTheme?
 
     @State private var viewModel = ViewModel()
     @StateObject private var playerViewModel = QuranPlayerViewModel()
@@ -79,52 +46,61 @@ public struct MushafView: View {
     @EnvironmentObject private var reciterService: ReciterService
     @EnvironmentObject private var toastManager: ToastManager
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.mushafReadingTheme) private var environmentReadingTheme
     @Environment(\.dismiss) private var dismiss
     @State private var playingVerse: Verse? = nil
     @State private var pageContentFrame: CGRect = .zero
 #if canImport(UIKit)
     @StateObject private var tiltManager = TiltScrollManager()
 #endif
-    @AppStorage("reading_theme") private var readingTheme: ReadingTheme = .white
+    @AppStorage("reading_theme") private var readingThemePreset: ReadingThemePreset = .white
     @AppStorage("scrolling_mode") private var scrollingMode: ScrollingMode = .horizontal
     @AppStorage("display_mode") private var displayMode: DisplayMode = .text
     @AppStorage("text_font_size") private var textFontSize: Double = 24.0
     @State private var textModeInitialChapter: Int = 1
     @State private var showEyeTrackingSettings: Bool = false
 
+    private var activeReadingTheme: ReadingTheme {
+        explicitReadingTheme ?? environmentReadingTheme ?? readingThemePreset.theme
+    }
+
 
     public init(initialPage: Int? = nil,
                 highlightedVerse: Verse? = nil,
                 onVerseLongPress: ((Verse) -> Void)? = nil,
-                onPageTap: (() -> Void)? = nil
+                onPageTap: (() -> Void)? = nil,
+                readingTheme: ReadingTheme? = nil
     ) {
         self.initialPage = initialPage
         self.staticHighlightedVerse = highlightedVerse
         self.highlightedVerseBinding = nil
         self.externalLongPressHandler = onVerseLongPress
         self.externalPageTapHandler = onPageTap
+        self.explicitReadingTheme = readingTheme
     }
 
     public init(initialPage: Int? = nil,
                 highlightedVerse: Binding<Verse?>,
                 onVerseLongPress: ((Verse) -> Void)? = nil,
-                onPageTap: (() -> Void)? = nil
+                onPageTap: (() -> Void)? = nil,
+                readingTheme: ReadingTheme? = nil
     ) {
         self.initialPage = initialPage
         self.highlightedVerseBinding = highlightedVerse
         self.staticHighlightedVerse = nil
         self.externalLongPressHandler = onVerseLongPress
         self.externalPageTapHandler = onPageTap
+        self.explicitReadingTheme = readingTheme
     }
 
     public var body: some View {
         ZStack {
-            readingTheme.color.ignoresSafeArea()
+            activeReadingTheme.backgroundColor.ignoresSafeArea()
             if viewModel.isLoading || !viewModel.isInitialPageReady {
                 LoadingView(message: viewModel.isLoading ? String(localized: "Loading Quran data...") : String(localized: "Preparing page..."))
             } else {
                 pageView
-                    .foregroundStyle(.naturalBlack)
+                    .foregroundStyle(activeReadingTheme.textColor)
             }
             
             // Eye tracking overlay (experimental)
@@ -137,7 +113,6 @@ public struct MushafView: View {
                 )
             }
         }
-        .environment(\.colorScheme, readingTheme == .night ? .dark : .light)
         .opacity(viewModel.contentOpacity)
         .overlay(alignment: .bottom) {
             if let verse = viewModel.selectedVerse, externalLongPressHandler == nil {


### PR DESCRIPTION
## Summary\n- introduce a dedicated public  model (background + text) and built-in  values\n- add package-level environment configuration via  so integrators can set a subtree default\n- update  to resolve theme from explicit parameter -> environment override -> persisted preset\n- remove the forced light appearance from the reciter settings sheet so settings UI follows system accessibility\n- document per-instance and package-level theme customization in README\n\n## Why\nThis keeps the reading surface visually stable based on user/developer preference instead of binding it to the device Light/Dark mode, while ensuring settings remain readable in either system appearance.\n\n## Notes\n- I could not run  in this container because the  toolchain is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable reading color themes with per-view override, package-level defaults, and clear override precedence.

* **Bug Fixes**
  * Theme-related picker now inherits system light/dark appearance instead of forcing light.

* **Documentation**
  * Updated theming guidance with examples showing per-instance and package-level configuration and the theme resolution order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->