### PR TITLE
chore: move personal tooling ignores to a local exclude file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,18 +51,6 @@ fastlane/test_output
 # Build server configuration (auto-generated)
 buildServer.json
 
-#AI
-copilot-instructions.md
-agents/
-CLAUDE.md
-AGENTS.md
-GEMINI.md
-.claude/
-.codex/
-.superpowers/
-docs/superpowers/
-.cursorrules
-
 # Private working notes (specs, plans, research) — never shipped
 notes/
 


### PR DESCRIPTION
`.gitignore` was carrying patterns for individual editor and assistant configuration. That is a per-developer concern, not a property of the project, so it now lives in `.git/info/exclude` locally.

What remains in `.gitignore` is what the repository itself produces: build output, Xcode state, `.DS_Store`, and private working notes.

No behaviour change for anyone cloning the repo.