### PR TITLE
a11y: VoiceOver labels for audio player controls

### DIFF
--- a/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
+++ b/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
@@ -182,7 +182,14 @@ public struct QuranPlayer: View {
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(Text(String(localized: "Recitation position")))
                 .accessibilityValue(Text(progressAccessibilityValue))
-                .accessibilityHint(Text(String(localized: "Adjusts recitation position")))
+                .accessibilityAdjustableAction { direction in
+                    guard progressGestureEnabled else { return }
+                    switch direction {
+                    case .increment: _ = viewModel.seekToNextVerse()
+                    case .decrement: _ = viewModel.seekToPreviousVerse()
+                    @unknown default: break
+                    }
+                }
             }
             .frame(height: 6)
 
@@ -209,9 +216,11 @@ public struct QuranPlayer: View {
             }
             .symbolRenderingMode(viewModel.isRepeatEnabled ? .multicolor : .hierarchical)
             .foregroundColor(viewModel.isRepeatEnabled ? accentColor : .brand900)
-            .accessibilityLabel(Text(viewModel.isRepeatEnabled
-                ? String(localized: "Repeat on")
-                : String(localized: "Repeat")))
+            .accessibilityLabel(Text(String(localized: "Repeat")))
+            .accessibilityValue(Text(viewModel.isRepeatEnabled
+                ? String(localized: "On")
+                : String(localized: "Off")))
+            .accessibilityAddTraits(viewModel.isRepeatEnabled ? .isSelected : [])
             
             Button(action: { onPreviousVerse?() }) {
                 Image(systemName: "backward.fill")
@@ -275,18 +284,22 @@ public struct QuranPlayer: View {
         viewModel.duration > 0 && !viewModel.isLoading
     }
 
+    private var recitationPosition: String? {
+        guard let verse = viewModel.currentVerseNumber else { return nil }
+        return verse == 0
+            ? String(localized: "Basmala")
+            : String(localized: "Verse \(verse)")
+    }
+
     private var progressAccessibilityValue: String {
-        if let verse = viewModel.currentVerseNumber, verse > 0 {
-            return String(localized: "Verse \(verse)")
-        }
-        return viewModel.currentTime.formatTime
+        let time = String(localized: "\(viewModel.currentTime.formatTime) elapsed, \(viewModel.remainingTime.formatTime) remaining")
+        guard let position = recitationPosition else { return time }
+        return "\(position), \(time)"
     }
 
     private var surahAccessibilityLabel: String {
-        if let verse = viewModel.currentVerseNumber, verse > 0 {
-            return "\(viewModel.chapterName), \(String(localized: "Verse \(verse)"))"
-        }
-        return viewModel.chapterName
+        guard let position = recitationPosition else { return viewModel.chapterName }
+        return "\(viewModel.chapterName), \(position)"
     }
 
     private func progressRatio(at x: CGFloat, width: CGFloat) -> Double {

--- a/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
+++ b/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
@@ -195,6 +195,7 @@ public struct QuranPlayer: View {
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(accentColor)
             }
+            .accessibilityHidden(true)
         }
     }
 

--- a/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
+++ b/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
@@ -99,6 +99,7 @@ public struct QuranPlayer: View {
                         .overlay(alignment: .bottomLeading) {
                             playbackStateView
                                 .offset(y:40)
+                                .accessibilityHidden(true)
                         }
                 }
         })
@@ -159,6 +160,8 @@ public struct QuranPlayer: View {
         .font(.system(size: 18, weight: .medium))
         .foregroundColor(.secondary)
         .frame(height: 30)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(surahAccessibilityLabel))
     }
 
     private var progressSection: some View {
@@ -277,6 +280,13 @@ public struct QuranPlayer: View {
             return String(localized: "Verse \(verse)")
         }
         return viewModel.currentTime.formatTime
+    }
+
+    private var surahAccessibilityLabel: String {
+        if let verse = viewModel.currentVerseNumber, verse > 0 {
+            return "\(viewModel.chapterName), \(String(localized: "Verse \(verse)"))"
+        }
+        return viewModel.chapterName
     }
 
     private func progressRatio(at x: CGFloat, width: CGFloat) -> Double {

--- a/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
+++ b/Sources/MushafImad/AudioPlayer/Views/QuranPlayer.swift
@@ -64,6 +64,7 @@ public struct QuranPlayer: View {
                     AirPlayRoutePickerView()
                         .frame(height: 50)
                         .padding(.top, 20)
+                        .accessibilityLabel(Text(String(localized: "AirPlay")))
                 }
             }
             .padding(20)
@@ -122,6 +123,8 @@ public struct QuranPlayer: View {
             .frame(height: 30)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(Text(String(localized: "Choose reciter")))
+        .accessibilityValue(Text(reciterService.selectedReciter?.displayName ?? viewModel.reciterName))
         .sheet(isPresented: $showReciterPicker) {
             ReciterPickerView(
                 reciters: reciterService.availableReciters,
@@ -173,6 +176,10 @@ public struct QuranPlayer: View {
                 .contentShape(Rectangle())
                 .gesture(progressGesture(in: geometry.size.width))
                 .allowsHitTesting(progressGestureEnabled)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(String(localized: "Recitation position")))
+                .accessibilityValue(Text(progressAccessibilityValue))
+                .accessibilityHint(Text(String(localized: "Adjusts recitation position")))
             }
             .frame(height: 6)
 
@@ -198,6 +205,9 @@ public struct QuranPlayer: View {
             }
             .symbolRenderingMode(viewModel.isRepeatEnabled ? .multicolor : .hierarchical)
             .foregroundColor(viewModel.isRepeatEnabled ? accentColor : .brand900)
+            .accessibilityLabel(Text(viewModel.isRepeatEnabled
+                ? String(localized: "Repeat on")
+                : String(localized: "Repeat")))
             
             Button(action: { onPreviousVerse?() }) {
                 Image(systemName: "backward.fill")
@@ -205,12 +215,16 @@ public struct QuranPlayer: View {
                     .opacity(onPreviousVerse == nil ? 0.35 : 1)
             }
             .disabled(onPreviousVerse == nil || viewModel.isLoading)
+            .accessibilityLabel(Text(String(localized: "Previous verse")))
             
             Button(action: viewModel.togglePlayback) {
                 Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")
                     .font(.system(size: 42))
             }
             .disabled(viewModel.isLoading && !viewModel.isPlaying)
+            .accessibilityLabel(Text(viewModel.isPlaying
+                ? String(localized: "Pause")
+                : String(localized: "Play")))
             
             Button(action: { onNextVerse?() }) {
                 Image(systemName: "forward.fill")
@@ -218,12 +232,14 @@ public struct QuranPlayer: View {
                     .opacity(onNextVerse == nil ? 0.35 : 1)
             }
             .disabled(onNextVerse == nil || viewModel.isLoading)
-            
+            .accessibilityLabel(Text(String(localized: "Next verse")))
             
             Button(action: viewModel.cyclePlaybackRate) {
                 Image(systemName: "gauge.with.dots.needle.50percent")
             }
             .disabled(viewModel.isLoading)
+            .accessibilityLabel(Text(String(localized: "Recitation speed \(playbackRateLabel(for: viewModel.playbackRate))")))
+            .accessibilityHint(Text(String(localized: "Change recitation speed")))
         }
         .font(.system(size: 22))
         .bold()
@@ -253,6 +269,13 @@ public struct QuranPlayer: View {
 
     private var progressGestureEnabled: Bool {
         viewModel.duration > 0 && !viewModel.isLoading
+    }
+
+    private var progressAccessibilityValue: String {
+        if let verse = viewModel.currentVerseNumber, verse > 0 {
+            return String(localized: "Verse \(verse)")
+        }
+        return viewModel.currentTime.formatTime
     }
 
     private func progressRatio(at x: CGFloat, width: CGFloat) -> Double {

--- a/Sources/MushafImad/Components/SheetHeader.swift
+++ b/Sources/MushafImad/Components/SheetHeader.swift
@@ -31,6 +31,7 @@ public struct SheetHeader<Content: View>: View {
                 Image(systemName: "xmark")
                     .font(.system(size: 17, weight: .semibold))
             }
+            .accessibilityLabel(Text(String(localized: "Close")))
             .frame(width: 44, height: 44)
             .background(.secondary.opacity(0.16), in: Circle())
             .foregroundStyle(.secondary)

--- a/Sources/MushafImad/Resources/Localizable.xcstrings
+++ b/Sources/MushafImad/Resources/Localizable.xcstrings
@@ -1,6 +1,26 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Adjusts recitation position" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ضبط موضع التلاوة"
+          }
+        }
+      }
+    },
+    "AirPlay" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirPlay"
+          }
+        }
+      }
+    },
     "AyahOfTheDay.description" : {
       "localizations" : {
         "ar" : {
@@ -450,6 +470,26 @@
         }
       }
     },
+    "Choose reciter" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختيار القارئ"
+          }
+        }
+      }
+    },
+    "Close" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إغلاق"
+          }
+        }
+      }
+    },
     "Comfy" : {
       "localizations" : {
         "ar" : {
@@ -466,6 +506,106 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "المصحف الكامل • ٦٠٤ صفحة"
+          }
+        }
+      }
+    },
+    "Change recitation speed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تبديل سرعة التلاوة"
+          }
+        }
+      }
+    },
+    "Next verse" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الآية التالية"
+          }
+        }
+      }
+    },
+    "Pause" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إيقاف مؤقت"
+          }
+        }
+      }
+    },
+    "Play" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تشغيل"
+          }
+        }
+      }
+    },
+    "Recitation position" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "موضع التلاوة"
+          }
+        }
+      }
+    },
+    "Recitation speed %@" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سرعة التلاوة %@"
+          }
+        }
+      }
+    },
+    "Previous verse" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الآية السابقة"
+          }
+        }
+      }
+    },
+    "Repeat" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تكرار"
+          }
+        }
+      }
+    },
+    "Repeat on" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التكرار مفعّل"
+          }
+        }
+      }
+    },
+    "Verse %lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الآية %lld"
           }
         }
       }

--- a/Sources/MushafImad/Resources/Localizable.xcstrings
+++ b/Sources/MushafImad/Resources/Localizable.xcstrings
@@ -1,16 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Adjusts recitation position" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ضبط موضع التلاوة"
-          }
-        }
-      }
-    },
     "AirPlay" : {
       "localizations" : {
         "ar" : {
@@ -78,6 +68,16 @@
     },
     "%@" : {
 
+    },
+    "%@ elapsed, %@ remaining" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ مضى، %@ متبقي"
+          }
+        }
+      }
     },
     "%lld" : {
       "localizations" : {
@@ -370,6 +370,16 @@
         }
       }
     },
+    "Basmala" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "البسملة"
+          }
+        }
+      }
+    },
     "Bookmark" : {
       "localizations" : {
         "ar" : {
@@ -436,6 +446,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إلغاء التنزيل؟"
+          }
+        }
+      }
+    },
+    "Change recitation speed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تبديل سرعة التلاوة"
           }
         }
       }
@@ -510,16 +530,6 @@
         }
       }
     },
-    "Change recitation speed" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تبديل سرعة التلاوة"
-          }
-        }
-      }
-    },
     "Next verse" : {
       "localizations" : {
         "ar" : {
@@ -550,6 +560,16 @@
         }
       }
     },
+    "Previous verse" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الآية السابقة"
+          }
+        }
+      }
+    },
     "Recitation position" : {
       "localizations" : {
         "ar" : {
@@ -570,42 +590,12 @@
         }
       }
     },
-    "Previous verse" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الآية السابقة"
-          }
-        }
-      }
-    },
     "Repeat" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "تكرار"
-          }
-        }
-      }
-    },
-    "Repeat on" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التكرار مفعّل"
-          }
-        }
-      }
-    },
-    "Verse %lld" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الآية %lld"
           }
         }
       }
@@ -1168,6 +1158,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ملاحظات"
+          }
+        }
+      }
+    },
+    "Off" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "غير مفعّل"
+          }
+        }
+      }
+    },
+    "On" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مفعّل"
           }
         }
       }
@@ -1786,6 +1796,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تم التحديث %@"
+          }
+        }
+      }
+    },
+    "Verse %lld" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الآية %lld"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Adds VoiceOver labels (and state-aware Play/Pause and Repeat) to Quran player controls and the sheet Close button.
- Progress control announces recitation position (verse or Basmala) plus elapsed and remaining time; swipe up/down seeks by verse via `accessibilityAdjustableAction`.
- The clock time labels under the progress bar stay visible but are hidden from VoiceOver, so swipe focus is not stuck on bare numbers — the seek control is the single progress announcement.
- The decorative playback status row (Paused icon + text, etc.) is hidden from VoiceOver to avoid repeating Play/Pause and to reach progress / surah sooner; surah + verse (or Basmala) is one combined accessibility label.
- Repeat keeps a constant label and puts On/Off in the value.
- New strings use `String(localized:)` with Arabic translations in `Localizable.xcstrings`.

Fixes #77

## Test plan
- [x] Enable VoiceOver and open the audio player
- [x] Swipe through controls without looking; confirm Play/Pause, next/previous verse, reciter, repeat, speed, close, and AirPlay are named by action
- [x] Toggle play and repeat; labels update with state
- [x] Progress announces verse (or Basmala) and elapsed/remaining time, rather than a bare number
- [x] Confirm the numeric time labels under the bar are skipped by VoiceOver (not announced as raw times)
- [x] Confirm Paused/status row is skipped; surah + verse reads as one item before progress
- [x] Confirm progress can actually move using only VoiceOver gestures (swipe up/down)
- [x] Opening of a non-Fatiha surah announces Basmala
- [ ] Optional: device language Arabic + VoiceOver Arabic speech → Arabic labels

AI assistance: used Cursor to draft accessibility modifiers and EN/AR strings; I verified against the issue checklist and tested on device with VoiceOver.