### PR TITLE
refactor(rendering): introduce the MushafRenderSource seam

### DIFF
--- a/Sources/MushafImad/QuranPageView.swift
+++ b/Sources/MushafImad/QuranPageView.swift
@@ -239,7 +239,7 @@ private struct LineImageView: View {
                 }
 
                 MushafRendering.configuration.renderSource
-                    .lineView(page: pageNumber, line: line, containerSize: geometry.size)
+                    .lineView(MushafRenderContext(page: pageNumber, line: line, containerSize: geometry.size))
                     .allowsHitTesting(false)
             }
         }

--- a/Sources/MushafImad/QuranPageView.swift
+++ b/Sources/MushafImad/QuranPageView.swift
@@ -73,13 +73,12 @@ public struct QuranPageView<Header: View, Footer: View>: View {
                     // Page lines
                     VStack(spacing:0) {
                         headerBuilder()
-                        ForEach(0...14,id: \.self) { line in
+                        ForEach(MushafPageGeometry.lineIndices, id: \.self) { line in
                             LineImageView(
                                 pageNumber: pageNumber,
                                 chapterheader: Array(page.chapterHeaders1441),
                                 line: line,
                                 verses: Array(page.verses1441),
-                                container: CGSize(width: availableWidth, height: lineHeight),
                                 selectedVerse: selectedVerse,
                                 highlightedVerse: initialHighlightedVerse,
                                 pressingVerseID: $pressingVerseID,
@@ -101,13 +100,12 @@ public struct QuranPageView<Header: View, Footer: View>: View {
                 // Portrait: Fit to screen without scrolling, header and footer fixed
                 VStack(spacing:0) {
                     headerBuilder()
-                    ForEach(0...14,id: \.self) { line in
+                    ForEach(MushafPageGeometry.lineIndices, id: \.self) { line in
                         LineImageView(
                             pageNumber: pageNumber,
                             chapterheader: Array(page.chapterHeaders1441),
                             line: line,
                             verses: Array(page.verses1441),
-                            container: CGSize(width: availableWidth, height: availableHeight),
                             selectedVerse: selectedVerse,
                             highlightedVerse: initialHighlightedVerse,
                             pressingVerseID: $pressingVerseID,
@@ -150,39 +148,33 @@ private struct LineImageView: View {
     let chapterheader: [ChapterHeader]
     let line: Int
     let verses: [Verse]
-    let container: CGSize
     let selectedVerse: Verse?
     let highlightedVerse: Verse?
     @Binding var pressingVerseID: Int?
     var onTap: (Verse) -> Void
-    // Original line image dimensions (all line images are 1440 x 232 pixels)
-    private let originalLineSize = CGSize(width: 1440, height: 232)
-    
+
     // Timer to delay highlight activation
     @State private var highlightTimer: Timer?
-    
+
     var selectedCorners: UIRectCorner {
         return [.allCorners]
     }
-    
+
     private func shouldHighlight(_ verse: Verse) -> Bool {
-        return selectedVerse?.verseID == verse.verseID || 
+        return selectedVerse?.verseID == verse.verseID ||
                highlightedVerse?.verseID == verse.verseID ||
                pressingVerseID == verse.verseID
     }
 
     @ViewBuilder
-    private func verseHighlightsView(verse: Verse, geometry: GeometryProxy) -> some View {
+    private func verseHighlightsView(verse: Verse, pageGeometry: MushafPageGeometry) -> some View {
         ForEach(verse.highlights1441.filter({ $0.line == line }), id: \.self) { highlight in
-            let visualLeftX = geometry.size.width * CGFloat(1.0 - highlight.right)
-            let visualRightX = geometry.size.width * CGFloat(1.0 - highlight.left)
-            let highlightWidth = visualRightX - visualLeftX
-            let highlightHeight = geometry.size.height * 0.94
-            
+            let placement = pageGeometry.highlightPlacement(for: highlight)
+
             Rectangle()
                 .fill(shouldHighlight(verse) ? Color(.accent900) : Color.clear)
                 .cornerRadius(8, corners: selectedCorners)
-                .frame(width: highlightWidth, height: highlightHeight)
+                .frame(width: placement.size.width, height: placement.size.height)
                 .contentShape(Rectangle())
                 .onLongPressGesture(minimumDuration: 1, pressing: { isPressing in
                     if isPressing {
@@ -207,7 +199,7 @@ private struct LineImageView: View {
                     pressingVerseID = nil
                     onTap(verse)
                 })
-                .position(x: visualLeftX + highlightWidth / 2, y: highlightHeight * 0.8)
+                .position(placement.center)
                 .background(
                     GeometryReader { proxy in
                         Color.clear.preference(
@@ -218,56 +210,37 @@ private struct LineImageView: View {
                 )
         }
     }
-    
+
     var body: some View {
-        let imageAspect = originalLineSize.width / originalLineSize.height
-        let containerWidth = container.width
-        
         ZStack {
             GeometryReader { geometry in
-                let scaledImageHeight = geometry.size.width / imageAspect
-                let cropOffset = (scaledImageHeight - geometry.size.height) / 2
-                let lineScale = geometry.size.width / originalLineSize.width
+                let pageGeometry = MushafPageGeometry(containerSize: geometry.size)
 
                 ForEach(verses, id: \.verseID) { verse in
-                    verseHighlightsView(verse: verse, geometry: geometry)
-                    
+                    verseHighlightsView(verse: verse, pageGeometry: pageGeometry)
+
                     // Only render marker if it belongs to this line
                     if let marker = verse.marker1441, marker.line == line {
-                        let markerX = geometry.size.width * CGFloat(1.0 - marker.centerX)
-                        
-                        let fullImageY = scaledImageHeight * CGFloat(marker.centerY)
-                        let markerY = fullImageY - cropOffset
-                        
-                        VerseFasel(number: verse.number, scale: lineScale)
-                            .position(x: markerX, y: markerY + 10)
+                        VerseFasel(number: verse.number, scale: pageGeometry.lineScale)
+                            .position(pageGeometry.markerCenter(for: marker))
                             .allowsHitTesting(false)
                     }
                 }
-                
+
                 ForEach(chapterheader, id: \.self){ chapterheader in
-                    let chapterX = geometry.size.width * CGFloat(1.0 - chapterheader.centerX)
-                    
-                    let fullImageY = scaledImageHeight * CGFloat(chapterheader.centerY)
-                    let chapterY = fullImageY - cropOffset
-                    
                     if chapterheader.line == line {
+                        let placement = pageGeometry.chapterBarPlacement(for: chapterheader)
                         MushafAssets.image(named: "suraNameBar")
                             .resizable()
-                            .frame(width:containerWidth * 0.9,height: scaledImageHeight * 0.8)
-                            .position(x: chapterX, y: chapterY + 8)
+                            .frame(width: placement.size.width, height: placement.size.height)
+                            .position(placement.center)
                             .allowsHitTesting(false)
                     }
                 }
-                
-                QuranLineImageView(
-                    page: pageNumber,
-                    line: line + 1,
-                    imageAspect: imageAspect,
-                    containerWidth: containerWidth,
-                    scaledImageHeight: scaledImageHeight
-                )
-                .allowsHitTesting(false)
+
+                MushafRendering.configuration.renderSource
+                    .lineView(page: pageNumber, line: line, containerSize: geometry.size)
+                    .allowsHitTesting(false)
             }
         }
     }

--- a/Sources/MushafImad/Rendering/LineImageRenderSource.swift
+++ b/Sources/MushafImad/Rendering/LineImageRenderSource.swift
@@ -11,14 +11,14 @@ import SwiftUI
 public struct LineImageRenderSource: MushafRenderSource {
     public init() {}
 
-    public func lineView(page: Int, line: Int, containerSize: CGSize) -> AnyView {
-        let geometry = MushafPageGeometry(containerSize: containerSize)
+    public func lineView(_ context: MushafRenderContext) -> AnyView {
+        let geometry = MushafPageGeometry(containerSize: context.containerSize)
         return AnyView(
             QuranLineImageView(
-                page: page,
-                line: line + 1,
+                page: context.page,
+                line: context.line + 1,
                 imageAspect: MushafPageGeometry.lineImageSize.width / MushafPageGeometry.lineImageSize.height,
-                containerWidth: containerSize.width,
+                containerWidth: context.containerSize.width,
                 scaledImageHeight: geometry.scaledImageHeight
             )
         )

--- a/Sources/MushafImad/Rendering/LineImageRenderSource.swift
+++ b/Sources/MushafImad/Rendering/LineImageRenderSource.swift
@@ -1,0 +1,26 @@
+//
+//  LineImageRenderSource.swift
+//  MushafImad
+//
+
+import SwiftUI
+
+/// The default `MushafRenderSource`: draws the bundled per-line PNGs via
+/// `QuranLineImageView`, reproducing the reader's original output exactly,
+/// including `.renderingMode(.template)` for `ReadingTheme` tinting.
+public struct LineImageRenderSource: MushafRenderSource {
+    public init() {}
+
+    public func lineView(page: Int, line: Int, containerSize: CGSize) -> AnyView {
+        let geometry = MushafPageGeometry(containerSize: containerSize)
+        return AnyView(
+            QuranLineImageView(
+                page: page,
+                line: line + 1,
+                imageAspect: MushafPageGeometry.lineImageSize.width / MushafPageGeometry.lineImageSize.height,
+                containerWidth: containerSize.width,
+                scaledImageHeight: geometry.scaledImageHeight
+            )
+        )
+    }
+}

--- a/Sources/MushafImad/Rendering/MushafPageGeometry.swift
+++ b/Sources/MushafImad/Rendering/MushafPageGeometry.swift
@@ -1,0 +1,97 @@
+//
+//  MushafPageGeometry.swift
+//  MushafImad
+//
+
+import SwiftUI
+
+/// A center point and size for placing a view via `.position(_:)` and `.frame(width:height:)`.
+public struct MushafElementPlacement: Equatable {
+    public let center: CGPoint
+    public let size: CGSize
+
+    public init(center: CGPoint, size: CGSize) {
+        self.center = center
+        self.size = size
+    }
+}
+
+/// The single source of truth for where verses live on a rendered Mushaf line.
+///
+/// Mirrors the Realm geometry contract — `VerseHighlight` (line, left, right),
+/// `VerseMarker` (line, centerX, centerY) and `ChapterHeader` (line, centerX,
+/// centerY), all normalized floats mirrored for RTL as `1.0 - x` — into
+/// concrete on-screen placements for a given line's container size. Every
+/// interactive feature (verse hit-testing, the selection/playback highlight,
+/// the ayah medallion, the surah name bar) reads from here, so swapping how a
+/// page is *drawn* (see `MushafRenderSource`) can never change where verses
+/// *are*.
+public struct MushafPageGeometry: Equatable {
+    /// The fixed pixel dimensions every canonical line is authored at.
+    public static let lineImageSize = CGSize(width: 1440, height: 232)
+
+    /// Every Mushaf page has exactly 15 lines, indexed 0...14.
+    public static let lineIndices: ClosedRange<Int> = 0...14
+
+    /// The on-screen size allotted to the line this geometry describes.
+    public let containerSize: CGSize
+
+    public init(containerSize: CGSize) {
+        self.containerSize = containerSize
+    }
+
+    private static var imageAspect: CGFloat {
+        lineImageSize.width / lineImageSize.height
+    }
+
+    /// Height the canonical line scales to once fit to the container's width,
+    /// before any vertical crop to the container's (usually shorter) height.
+    public var scaledImageHeight: CGFloat {
+        containerSize.width / Self.imageAspect
+    }
+
+    /// How far the scaled line is cropped, top and bottom, to fit the container's height.
+    public var cropOffset: CGFloat {
+        (scaledImageHeight - containerSize.height) / 2
+    }
+
+    /// Scale factor from the canonical 1440pt-wide line to the container's width.
+    /// Used to size line-relative overlays such as the ayah medallion.
+    public var lineScale: CGFloat {
+        containerSize.width / Self.lineImageSize.width
+    }
+
+    /// Mirrors a normalized x-coordinate for RTL layout.
+    public static func mirroredX(_ x: Float) -> CGFloat {
+        CGFloat(1.0 - x)
+    }
+
+    /// The on-screen center and size of a verse's highlight rect on this line.
+    public func highlightPlacement(for highlight: VerseHighlight) -> MushafElementPlacement {
+        let left = containerSize.width * Self.mirroredX(highlight.right)
+        let right = containerSize.width * Self.mirroredX(highlight.left)
+        let width = right - left
+        let height = containerSize.height * 0.94
+        return MushafElementPlacement(
+            center: CGPoint(x: left + width / 2, y: height * 0.8),
+            size: CGSize(width: width, height: height)
+        )
+    }
+
+    /// The on-screen center of a verse's ayah medallion on this line.
+    public func markerCenter(for marker: VerseMarker) -> CGPoint {
+        let x = containerSize.width * Self.mirroredX(marker.centerX)
+        let y = (scaledImageHeight * CGFloat(marker.centerY) - cropOffset) + 10
+        return CGPoint(x: x, y: y)
+    }
+
+    /// The on-screen center and size of a surah name bar on this line.
+    public func chapterBarPlacement(for header: ChapterHeader) -> MushafElementPlacement {
+        let x = containerSize.width * Self.mirroredX(header.centerX)
+        let y = (scaledImageHeight * CGFloat(header.centerY) - cropOffset) + 8
+        return MushafElementPlacement(
+            center: CGPoint(x: x, y: y),
+            size: CGSize(width: containerSize.width * 0.9, height: scaledImageHeight * 0.8)
+        )
+    }
+}

--- a/Sources/MushafImad/Rendering/MushafRenderConfiguration.swift
+++ b/Sources/MushafImad/Rendering/MushafRenderConfiguration.swift
@@ -1,0 +1,33 @@
+//
+//  MushafRenderConfiguration.swift
+//  MushafImad
+//
+
+import SwiftUI
+
+/// Configuration entry point that lets host applications choose how Mushaf
+/// pages are drawn, following the same override pattern as
+/// `MushafAssetConfiguration`.
+///
+/// This only governs pages rendered by `QuranPageView` (`DisplayMode.image`
+/// in `MushafView`). `DisplayMode.text` renders through an entirely separate
+/// text view and is unaffected by this configuration.
+public struct MushafRenderConfiguration {
+    public var renderSource: any MushafRenderSource
+
+    public init(renderSource: any MushafRenderSource = LineImageRenderSource()) {
+        self.renderSource = renderSource
+    }
+}
+
+/// Runtime access to the active render source, honoring any override supplied by the host app.
+@MainActor
+public enum MushafRendering {
+    /// Active configuration. Update this at launch or inside previews to override the default.
+    public static var configuration = MushafRenderConfiguration()
+
+    /// Reset to the default configuration (useful for examples and tests).
+    public static func reset() {
+        configuration = MushafRenderConfiguration()
+    }
+}

--- a/Sources/MushafImad/Rendering/MushafRenderConfiguration.swift
+++ b/Sources/MushafImad/Rendering/MushafRenderConfiguration.swift
@@ -12,6 +12,7 @@ import SwiftUI
 /// This only governs pages rendered by `QuranPageView` (`DisplayMode.image`
 /// in `MushafView`). `DisplayMode.text` renders through an entirely separate
 /// text view and is unaffected by this configuration.
+@MainActor
 public struct MushafRenderConfiguration {
     public var renderSource: any MushafRenderSource
 

--- a/Sources/MushafImad/Rendering/MushafRenderSource.swift
+++ b/Sources/MushafImad/Rendering/MushafRenderSource.swift
@@ -27,7 +27,24 @@ import SwiftUI
 ///
 /// The active source is read from `MushafRendering.configuration`, following
 /// the same override pattern as `MushafAssets.configuration`.
+@MainActor
 public protocol MushafRenderSource {
-    /// The visual for line `line` (0...14) of page `page`, sized to `containerSize`.
-    func lineView(page: Int, line: Int, containerSize: CGSize) -> AnyView
+    /// The visual for the line described by `context`.
+    func lineView(_ context: MushafRenderContext) -> AnyView
+}
+
+/// What a render source needs to know to draw one line: which page, which
+/// line (0...14), and the box it must fit within. A struct rather than loose
+/// parameters so future axes (e.g. the 1405 layout in #74) can be added
+/// without re-signing this public protocol requirement.
+public struct MushafRenderContext {
+    public let page: Int
+    public let line: Int
+    public let containerSize: CGSize
+
+    public init(page: Int, line: Int, containerSize: CGSize) {
+        self.page = page
+        self.line = line
+        self.containerSize = containerSize
+    }
 }

--- a/Sources/MushafImad/Rendering/MushafRenderSource.swift
+++ b/Sources/MushafImad/Rendering/MushafRenderSource.swift
@@ -1,0 +1,33 @@
+//
+//  MushafRenderSource.swift
+//  MushafImad
+//
+
+import SwiftUI
+
+/// Produces the visual for one line of a Mushaf page.
+///
+/// A render source's only job is drawing pixels for the line it's given —
+/// a line image today, potentially a cropped page image, an SVG, or
+/// glyph-rendered text in the future. It:
+///
+/// - **Must** return content sized to fit `containerSize` (the box
+///   `QuranPageView` has already laid out for this line).
+/// - **Must** apply `.renderingMode(.template)` (or equivalent) to any
+///   bitmap/vector artwork it draws, so `ReadingTheme` tinting keeps working.
+/// - **Must not** know about verses, highlights, ayah medallions, surah name
+///   bars, or any other interaction concern. That geometry always comes from
+///   `MushafPageGeometry` and Realm, drawn by `QuranPageView` itself on top
+///   of whatever the render source produces — never inside it. This is what
+///   lets every render source inherit verse selection, tafseer, and
+///   follow-the-reciter highlighting for free.
+/// - **Must not** perform hit-testing or attach gestures; `QuranPageView`
+///   disables hit-testing on the render source's output and owns all touch
+///   handling itself.
+///
+/// The active source is read from `MushafRendering.configuration`, following
+/// the same override pattern as `MushafAssets.configuration`.
+public protocol MushafRenderSource {
+    /// The visual for line `line` (0...14) of page `page`, sized to `containerSize`.
+    func lineView(page: Int, line: Int, containerSize: CGSize) -> AnyView
+}


### PR DESCRIPTION
## Summary

`QuranPageView` and its private `LineImageView` did two jobs at once: drawing line images *and* owning all verse geometry (highlight rects from `VerseHighlight.line/left/right`, ayah medallion placement from `VerseMarker.centerX/centerY`, surah name bar placement from `ChapterHeader.centerX/centerY`, RTL mirroring as `1.0 - x`). Because the two were tangled, there was no way to change how a page is drawn without reimplementing verse interaction from scratch — blocking every other issue in the render-sources epic (#76).

This separates "what a page looks like" from "where the verses are," with **zero behavior change**.

## Changes

- **`MushafPageGeometry`** — the single source of truth for verse highlight rects, ayah medallion positions, surah bar positions, RTL mirroring, and the canonical page shape (15 lines, `0...14`). Every formula is carried over verbatim from the original inline math in `LineImageView` — I traced each one by hand to guarantee identical output.
- **`MushafRenderSource`** protocol — its only job is producing the visual for a page/line. Documented (doc comment on the type) with what a source must and must not do: must draw within `containerSize` and apply `.renderingMode(.template)`; must never know about verses, highlights, markers, chapter bars, or perform hit-testing — that stays owned by `QuranPageView`/`MushafPageGeometry`, so every future source (page-image, SVG, glyph-font) inherits verse interaction for free.
- **`LineImageRenderSource`** — the default source, reproducing today's output exactly by wrapping the existing `QuranLineImageView` unchanged (including `.renderingMode(.template)`, so `ReadingTheme` tinting still works).
- **`MushafRenderConfiguration` / `MushafRendering`** — configuration entry point following the exact same override pattern as `MushafAssetConfiguration` / `MushafAssets` (as requested in the issue, no second mechanism invented).
- `QuranPageView`'s private `LineImageView` now delegates placement math to `MushafPageGeometry` and pixel drawing to `MushafRendering.configuration.renderSource`, instead of doing both inline. **`QuranPageView`'s own public API is unchanged.**

## Design decision: DisplayMode

The new configuration **sits beneath `DisplayMode.image`**. `DisplayMode.text` renders through a completely separate view (`MushafTextView`) and is untouched by this change. I chose this over absorbing `DisplayMode` into the render-source system because:
- It keeps the change **purely additive** — no existing public symbol removed or re-signed, no breaking change to the `DisplayMode` enum.
- The issue's goal (a page-image/SVG/glyph-font seam) only concerns *how image-mode pages are drawn*; text mode is a fundamentally different rendering strategy (verse-level text layout, not page/line images) that doesn't fit the same "draws a line" contract.

## Out of scope (per the issue)

- No new render source added.
- 1405 layout support untouched.
- Eye tracking untouched — confirmed via diff that `GazeToVerseMapper.swift` was not touched at all; its public inputs (`isLandscape`, `scrollOffset`, both with defaults, from #92) are unaffected.

## Test plan

- `swift build`: clean, no errors.
- `swift test --no-parallel`: **160 tests passed**, **11 known issues** — this matches `main`'s baseline exactly (this branch is off `main`, before #92 merges, so all original eye-tracking known-issue markers are still present; no new known issues, nothing regressed).
- Manually verified on an iPad Air 11" (M4) simulator, image mode:
  - Portrait and landscape rendering: surah name bar, ayah medallions, and line images all positioned correctly, no visual differences from expected output.
  - Landscape scroll works.
  - Verse long-press → highlight + tafseer sheet works.
  - Follow-the-reciter highlighting relies on the same `SelectedVerseRectKey` preference plumbing, untouched by this refactor.
- Two things I initially suspected might be regressions turned out to be pre-existing, confirmed unrelated to this refactor (their code paths are untouched by this diff):
  - Portrait doesn't scroll — intentional "fit to screen" design already on `main` (see the `// Portrait: Fit to screen without scrolling` comment), not a bug.
  - Page 1 has a large blank margin above the sura title bar — authentic artwork specific to page 1; confirmed normal spacing on other pages.
