### PR TITLE
chore(logging): route font debug helper through AppLogger

### DIFF
--- a/Sources/MushafImad/Core/Extensions/Fonts+Extension.swift
+++ b/Sources/MushafImad/Core/Extensions/Fonts+Extension.swift
@@ -90,23 +90,26 @@ enum CustomFontName: String {
 
 #if DEBUG
 extension Font {
-    /// Prints all available font families and their font names to console
-    /// Use this to find the correct PostScript name for your custom fonts
+    /// Logs all available font families and their font names.
+    /// Use this to find the correct PostScript name for your custom fonts.
+    /// Routed through AppLogger (category `.ui`, like FontRegistrar) instead of
+    /// `print` so the output is filterable in Console.app and stays out of
+    /// host apps' stdout.
     static func printAvailableFonts() {
         #if canImport(UIKit) && DEBUG
-        print("=== Available Font Families ===")
+        AppLogger.shared.debug("=== Available Font Families ===", category: .ui)
         for family in UIFont.familyNames.sorted() {
-            print("\nFamily: \(family)")
+            AppLogger.shared.debug("\nFamily: \(family)", category: .ui)
             for fontName in UIFont.fontNames(forFamilyName: family) {
-                print("  - \(fontName)")
+                AppLogger.shared.debug("  - \(fontName)", category: .ui)
             }
         }
-        print("\n=== Custom Fonts ===")
+        AppLogger.shared.debug("\n=== Custom Fonts ===", category: .ui)
         let customFontFiles = ["SurahName.otf", "HafsSmart_08.ttf", "Kitab-Bold.ttf",
                                "Kitab-Regular.ttf", "QuranNumbers.ttf", "QuranTitles.ttf",
                                "UthmanicHafs1 Ver17.ttf", "UthmanTN1 Ver20.ttf", "UthmanTN1B Ver20.ttf"]
         for fontFile in customFontFiles {
-            print("File: \(fontFile)")
+            AppLogger.shared.debug("File: \(fontFile)", category: .ui)
         }
         #endif
     }

--- a/Sources/MushafImad/TiltScrollManager.swift
+++ b/Sources/MushafImad/TiltScrollManager.swift
@@ -242,7 +242,6 @@ public class TiltScrollManager: ObservableObject {
     private func updateScrollPosition() {
 #if canImport(UIKit)
         guard let scrollView = scrollView else {
-            // print("[TiltScrollManager] No ScrollView to scroll")
             return
         }
         
@@ -255,7 +254,6 @@ public class TiltScrollManager: ObservableObject {
             return
         }
         
-        // print("[TiltScrollManager] Scrolling by \(scrollVelocity)")
         if scrollAxis == .vertical {
             let newOffset = CGPoint(
                 x: scrollView.contentOffset.x,


### PR DESCRIPTION
## Summary

Routes the font-debug helper through `AppLogger` instead of `print`, and removes dead
commented-out logging. After this change, `grep -rn "print(" Sources` finds only the logger's
own console sink in `AppLogger.swift` (which must stay).

Refs #78

## Changes

- `Sources/MushafImad/Core/Extensions/Fonts+Extension.swift`: the five `print` calls in
  `Font.printAvailableFonts()` become `AppLogger.shared.debug(..., category: .ui)` — the same
  call shape and category `FontRegistrar` already uses for font diagnostics, so a host app
  debugging a missing font filters one category in Console.app. Doc comment updated.
- `Sources/MushafImad/TiltScrollManager.swift`: deleted the two dead `// print(...)` lines.

## Notes on the issue's open questions

- **Category**: no new category added — `.ui` is the close match already used for font
  registration diagnostics in `FontRegistrar.swift`.
- **`#if DEBUG`**: kept as-is. The helper was already compiled out of release builds by the
  outer `#if DEBUG`, and `AppLogger` additionally drops `debug` below `.info` in release, so
  behavior is unchanged on both dimensions.

## Verification

- No Swift toolchain on this machine, so I verified structurally: every new call matches the
  existing `AppLogger.shared.debug(_:category:)` call sites exactly, no new imports are needed
  (same module), and the `#if DEBUG` / `#if canImport(UIKit)` nesting is untouched. Relying on
  CI for the Xcode build.
