### PR TITLE
feat(i18n): complete Arabic strings for tilt and eye-tracking settings

### DIFF
--- a/Sources/MushafImad/EyeTracking/EyeTrackingSettingsView.swift
+++ b/Sources/MushafImad/EyeTracking/EyeTrackingSettingsView.swift
@@ -244,7 +244,7 @@ public struct EyeTrackingSettingsView: View {
     // MARK: - Helpers
     
     @ViewBuilder
-    private func privacyItem(icon: String, text: String) -> some View {
+    private func privacyItem(icon: String, text: LocalizedStringKey) -> some View {
         HStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.system(size: 12))

--- a/Sources/MushafImad/Resources/Localizable.xcstrings
+++ b/Sources/MushafImad/Resources/Localizable.xcstrings
@@ -1882,6 +1882,386 @@
     },
     "سورة %@" : {
       "shouldTranslate" : false
+    },
+    "Tilt to Scroll" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التمرير بالإمالة"
+          }
+        }
+      }
+    },
+    "Enable Tilt Scrolling" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تفعيل التمرير بالإمالة"
+          }
+        }
+      }
+    },
+    "Sensitivity" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الحساسية"
+          }
+        }
+      }
+    },
+    "Slow" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بطيء"
+          }
+        }
+      }
+    },
+    "Fast" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سريع"
+          }
+        }
+      }
+    },
+    "Tilt your device forward or backward to scroll automatically. Return to a neutral reading angle (~25°) to stop." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أمِل جهازك للأمام أو للخلف للتمرير تلقائيًا، وعُد إلى زاوية قراءة محايدة (25° تقريبًا) للتوقف."
+          }
+        }
+      }
+    },
+    "Scroll Settings" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعدادات التمرير"
+          }
+        }
+      }
+    },
+    "Experimental Feature" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ميزة تجريبية"
+          }
+        }
+      }
+    },
+    "Eye tracking is a research feature. Accuracy may vary by device and lighting conditions." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تتبع العين ميزة بحثية. قد تختلف الدقة حسب الجهاز وظروف الإضاءة."
+          }
+        }
+      }
+    },
+    "Enable Eye Tracking" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تفعيل تتبع العين"
+          }
+        }
+      }
+    },
+    "Device Support" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "دعم الجهاز"
+          }
+        }
+      }
+    },
+    "Supported" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مدعوم"
+          }
+        }
+      }
+    },
+    "Not Available" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "غير متوفر"
+          }
+        }
+      }
+    },
+    "Use Reading Estimation" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استخدام تقدير القراءة"
+          }
+        }
+      }
+    },
+    "Estimates progress based on reading speed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يقدّر تقدم القراءة بناءً على سرعتها"
+          }
+        }
+      }
+    },
+    "Tracking" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التتبع"
+          }
+        }
+      }
+    },
+    "Eye tracking requires an iPhone with TrueDepth camera (iPhone X or later). Your camera data stays entirely on-device and is never stored or transmitted." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يتطلب تتبع العين iPhone مزودًا بكاميرا TrueDepth (iPhone X أو أحدث). تبقى بيانات الكاميرا على جهازك بالكامل، ولا تُخزَّن أو تُنقَل أبدًا."
+          }
+        }
+      }
+    },
+    "Auto-Highlight Verse" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تمييز الآية تلقائيًا"
+          }
+        }
+      }
+    },
+    "Highlights the verse you're reading" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يُميِّز الآية التي تقرؤها"
+          }
+        }
+      }
+    },
+    "Auto-Advance Page" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تقديم الصفحة تلقائيًا"
+          }
+        }
+      }
+    },
+    "Automatically flip to next page when finished reading" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الانتقال تلقائيًا إلى الصفحة التالية عند الانتهاء من القراءة"
+          }
+        }
+      }
+    },
+    "Behavior" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "السلوك"
+          }
+        }
+      }
+    },
+    "Dwell Time" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مدة التثبيت"
+          }
+        }
+      }
+    },
+    "How long your gaze must rest on a verse before it's marked as read" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المدة التي يجب أن يستقر فيها نظرك على الآية قبل تعليمها كمقروءة"
+          }
+        }
+      }
+    },
+    "Reading Speed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سرعة القراءة"
+          }
+        }
+      }
+    },
+    "Arabic words per minute (used for fallback estimation)" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "كلمات عربية في الدقيقة (تُستخدم للتقدير الاحتياطي)"
+          }
+        }
+      }
+    },
+    "Tuning" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الضبط"
+          }
+        }
+      }
+    },
+    "Show Tracking Overlay" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إظهار طبقة التتبع"
+          }
+        }
+      }
+    },
+    "Show Debug Info" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إظهار معلومات التصحيح"
+          }
+        }
+      }
+    },
+    "Developer" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المطور"
+          }
+        }
+      }
+    },
+    "These options are for testing and development. The overlay shows a dot where your gaze is estimated to be." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هذه الخيارات للاختبار والتطوير. تُظهر الطبقة نقطةً في موضع نظرك المقدَّر."
+          }
+        }
+      }
+    },
+    "Privacy Commitment" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الالتزام بالخصوصية"
+          }
+        }
+      }
+    },
+    "Camera data is processed on-device only" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تُعالَج بيانات الكاميرا على الجهاز فقط"
+          }
+        }
+      }
+    },
+    "No gaze data is uploaded or stored" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا تُرفَع بيانات النظر ولا تُخزَّن"
+          }
+        }
+      }
+    },
+    "Feature is entirely opt-in" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الميزة اختيارية بالكامل"
+          }
+        }
+      }
+    },
+    "Stop tracking to immediately release camera" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أوقِف التتبع لتحرير الكاميرا فورًا"
+          }
+        }
+      }
+    },
+    "Eye Tracking" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تتبع العين"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Sources/MushafImad/TiltSettingsView.swift
+++ b/Sources/MushafImad/TiltSettingsView.swift
@@ -36,7 +36,7 @@ public struct TiltSettingsView: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .navigationTitle("Scroll Settings")
+        .navigationTitle(String(localized: "Scroll Settings"))
     }
 }
 


### PR DESCRIPTION
## Summary

Completes the Arabic coverage for the tilt-to-scroll and eye-tracking settings screens: 38 new
translated entries in `Localizable.xcstrings`, plus routing the two remaining plain-`String` UI
sites through localization so the translations actually resolve.

Refs #80

## Changes

- `Sources/MushafImad/Resources/Localizable.xcstrings`: 38 new `ar` entries (`state: translated`),
  covering the full tilt screen (7 strings) and the full eye-tracking screen (31 strings). No
  format specifiers involved; nothing else in the file touched (pure 380-line addition).
- `Sources/MushafImad/TiltSettingsView.swift`: `.navigationTitle("Scroll Settings")` now goes
  through `String(localized:)` — a plain `String` title never hits the catalog, so the new entry
  would otherwise be dead. Same pattern already used in `EyeTrackingSettingsView`.
- `Sources/MushafImad/EyeTracking/EyeTrackingSettingsView.swift`: `privacyItem(text:)` now takes
  `LocalizedStringKey` instead of `String`, so its four call-site literals resolve. Call sites
  unchanged (literals convert implicitly).

## Notes for review

- **Terminology**: `تتبع العين` for "eye tracking" (proposed in the issue comments, adjustable);
  `مدة التثبيت` for "Dwell Time"; `الضبط` for "Tuning". Everything else follows established
  in-app vocabulary where it exists.
- **Already done upstream**: the issue lists `Daily pages: %lld` and `Share %lld Ayahs` as empty,
  but both already carry complete translated plural forms on `main` — verified, no change made.
  Likewise the four untranslated fragment keys (`%@`, `-%@`, `AA`, `سورة %@`) are intentionally
  untouched as out of scope.
- **No Swift toolchain on this machine**: verified by script instead — the catalog parses as
  JSON, all 38 entries are `translated` with non-empty values, and a sweep of both Swift files
  confirms every `Text`/`Toggle`/`String(localized:)` literal now resolves to a translated `ar`
  entry. Relying on CI for the Xcode build.
