### PR TITLE
test(gaze): fix timing artifacts, drop false progression marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,7 @@ A Swift Package that delivers a fully featured Mushaf (Quran) reading experience
 ### Eye Tracking (Experimental)
 
 > [!WARNING]
-> **Eye tracking is experimental and not recommended for production.** Its gaze estimation is
-> incomplete: the fallback estimator's gaze does not advance down the page over time. The
-> corresponding test is marked as a known issue (see
-> `Tests/MushafImadSPMTests/ExperimentalEyeTrackingKnownIssues.swift`).
+> **Eye tracking is experimental and not recommended for production.**
 >
 > The feature is opt-in and self-contained — nothing else in the package depends on it, and the
 > Mushaf reader and audio playback are unaffected if you never enable it.

--- a/Tests/MushafImadSPMTests/ExperimentalEyeTrackingKnownIssues.swift
+++ b/Tests/MushafImadSPMTests/ExperimentalEyeTrackingKnownIssues.swift
@@ -8,12 +8,3 @@ import Testing
 // signal that the underlying work has landed and the marker should come off.
 //
 // Nothing outside the eye-tracking feature depends on these paths.
-
-/// `FallbackGazeEstimator.estimatedGaze` does not advance down the page as time
-/// passes: `screenPosition.y` holds its initial value regardless of elapsed time
-/// or `arabicWordsPerMinute`, so progression, speed, resume, and reset all
-/// observe the same static point.
-let experimentalGazeProgression: Comment = """
-Experimental eye tracking: FallbackGazeEstimator's estimated gaze does not \
-progress over time — screenPosition.y stays at its initial value.
-"""

--- a/Tests/MushafImadSPMTests/FallbackGazeEstimatorTests.swift
+++ b/Tests/MushafImadSPMTests/FallbackGazeEstimatorTests.swift
@@ -155,13 +155,14 @@ struct FallbackGazeEstimatorTests {
         try? await Task.sleep(nanoseconds: 300_000_000)
         let firstGaze = try #require(await waitForGaze(from: estimator))
 
-        try? await Task.sleep(nanoseconds: 500_000_000)
+        // Wait past one full line: secondsPerLine is 600 / WPM (1.0 s at 600),
+        // plus slack so CI scheduling delay cannot leave both samples on line 0.
+        let lineTime = 600.0 / estimator.arabicWordsPerMinute
+        try? await Task.sleep(nanoseconds: UInt64((lineTime + 0.2) * 1_000_000_000))
         let secondGaze = try #require(await waitForGaze(from: estimator))
 
         // Assert - Y position should increase (moving down the page)
-        withKnownIssue(experimentalGazeProgression) {
-            #expect(secondGaze.screenPosition.y > firstGaze.screenPosition.y)
-        }
+        #expect(secondGaze.screenPosition.y > firstGaze.screenPosition.y)
     }
     
     @Test
@@ -193,24 +194,27 @@ struct FallbackGazeEstimatorTests {
         // Arrange
         let estimator = FallbackGazeEstimator()
         let pageFrame = CGRect(x: 0, y: 0, width: 375, height: 812)
+        let slowWPM = 40.0
+        let fastWPM = 200.0
+        // Sample after the fast rate has crossed a line (600 / 200 = 3 s) but
+        // long before the slow rate does (600 / 40 = 15 s).
+        let waitNanoseconds = UInt64((600.0 / fastWPM + 1.0) * 1_000_000_000)
         
         // Test with slow reading speed
-        estimator.arabicWordsPerMinute = 40
+        estimator.arabicWordsPerMinute = slowWPM
         estimator.startForPage(pageFrame: pageFrame)
-        try? await Task.sleep(nanoseconds: 300_000_000)
+        try? await Task.sleep(nanoseconds: waitNanoseconds)
         let slowGaze = try #require(await waitForGaze(from: estimator))
         estimator.stopEstimating()
 
         // Test with fast reading speed
-        estimator.arabicWordsPerMinute = 200
+        estimator.arabicWordsPerMinute = fastWPM
         estimator.startForPage(pageFrame: pageFrame)
-        try? await Task.sleep(nanoseconds: 300_000_000)
+        try? await Task.sleep(nanoseconds: waitNanoseconds)
         let fastGaze = try #require(await waitForGaze(from: estimator))
 
         // Assert - faster reading should progress further down the page
-        withKnownIssue(experimentalGazeProgression) {
-            #expect(fastGaze.screenPosition.y > slowGaze.screenPosition.y)
-        }
+        #expect(fastGaze.screenPosition.y > slowGaze.screenPosition.y)
     }
     
     @Test
@@ -265,13 +269,13 @@ struct FallbackGazeEstimatorTests {
         estimator.resume()
         
         let afterResume = try #require(await waitForGaze(from: estimator))
-        try? await Task.sleep(nanoseconds: 500_000_000)
+        // Wait past one full line (600 / WPM + slack), as above.
+        let lineTime = 600.0 / estimator.arabicWordsPerMinute
+        try? await Task.sleep(nanoseconds: UInt64((lineTime + 0.2) * 1_000_000_000))
         let afterMoreTime = try #require(await waitForGaze(from: estimator))
 
         // Assert - should continue progressing after resume
-        withKnownIssue(experimentalGazeProgression) {
-            #expect(afterMoreTime.screenPosition.y > afterResume.screenPosition.y)
-        }
+        #expect(afterMoreTime.screenPosition.y > afterResume.screenPosition.y)
     }
     
     @Test
@@ -323,7 +327,10 @@ struct FallbackGazeEstimatorTests {
         
         // Act
         estimator.startForPage(pageFrame: pageFrame)
-        try? await Task.sleep(nanoseconds: 500_000_000)
+        // Settle past the first line (600 / WPM = 1.0 s at 600, plus slack)
+        // so the pre-reset sample is genuinely below the post-reset one.
+        let lineTime = 600.0 / estimator.arabicWordsPerMinute
+        try? await Task.sleep(nanoseconds: UInt64((lineTime + 0.5) * 1_000_000_000))
         let beforeReset = try #require(await waitForGaze(from: estimator))
 
         estimator.resetPageTimer()
@@ -331,9 +338,7 @@ struct FallbackGazeEstimatorTests {
         let afterReset = try #require(await waitForGaze(from: estimator))
 
         // Assert - after reset, should be back near the top
-        withKnownIssue(experimentalGazeProgression) {
-            #expect(afterReset.screenPosition.y < beforeReset.screenPosition.y)
-        }
+        #expect(afterReset.screenPosition.y < beforeReset.screenPosition.y)
     }
     
     // MARK: - Confidence Calculation Tests


### PR DESCRIPTION
## Summary

Implements #91 exactly as specified: the four `experimentalGazeProgression` failures are
test-timing artifacts (both samples land on the same quantised line), not production bugs, so
the waits are widened to straddle a `secondsPerLine` boundary and the false marker is removed.

Refs #91

## Changes

- `Tests/.../FallbackGazeEstimatorTests.swift`: the four waits now derive from
  `600 / arabicWordsPerMinute` (plus explicit slack) instead of magic sleeps that sat 0.2–0.5 s
  from a step boundary — 1.2 s second sleeps at 600 WPM, 4 s for the 40→200 WPM comparison
  (clears the 3 s fast line, far short of the 15 s slow line), 1.5 s pre-reset sample. The four
  `withKnownIssue` blocks are unwrapped.
- `Tests/.../ExperimentalEyeTrackingKnownIssues.swift`: deleted the `experimentalGazeProgression`
  marker and its doc comment (no remaining references anywhere in the tree).
- `README.md`: corrected the warning that repeated the disproven claim
  ("the fallback estimator's gaze does not advance down the page over time").

## Notes

- No production code touched — the estimator already steps one line per `secondsPerLine`, as the
  issue measured.
- The issue mentions updating an 11→7 count in `CLAUDE.md`: neither that file nor any quoted
  count exists in this tree (only these four marker uses), so there was nothing to update.
- The other markers were explicitly not audited here, per the issue.
- No Swift toolchain on this machine: the edits follow the issue's measured values line by line
  (waits, assertions, unwrapping), and the new expressions use only already-imported,
  already-used APIs (`Task.sleep`, `Double` arithmetic). Relying on CI (`swift test --no-parallel`)
  for execution.
